### PR TITLE
Persist intercept & catch_exceptions options between kernel reboot

### DIFF
--- a/src/InteractsWithMessenger.php
+++ b/src/InteractsWithMessenger.php
@@ -4,7 +4,6 @@ namespace Zenstruck\Messenger\Test;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Messenger\Test\Transport\TestTransport;
-use Zenstruck\Messenger\Test\Transport\TestTransportFactory;
 use Zenstruck\Messenger\Test\Transport\TestTransportRegistry;
 
 /**
@@ -13,12 +12,11 @@ use Zenstruck\Messenger\Test\Transport\TestTransportRegistry;
 trait InteractsWithMessenger
 {
     /**
-     * @internal
      * @after
      */
-    final protected function _resetTransports(): void
+    final protected function resetTransports(): void
     {
-        TestTransportFactory::reset();
+        TestTransport::reset();
     }
 
     final protected function messenger(?string $transport = null): TestTransport

--- a/src/InteractsWithMessenger.php
+++ b/src/InteractsWithMessenger.php
@@ -12,11 +12,12 @@ use Zenstruck\Messenger\Test\Transport\TestTransportRegistry;
 trait InteractsWithMessenger
 {
     /**
+     * @internal
      * @after
      */
-    final protected function resetTransports(): void
+    final protected static function _resetMessengerTransports(): void
     {
-        TestTransport::reset();
+        TestTransport::resetAll();
     }
 
     final protected function messenger(?string $transport = null): TestTransport

--- a/src/Transport/TestTransport.php
+++ b/src/Transport/TestTransport.php
@@ -41,10 +41,10 @@ final class TestTransport implements TransportInterface
     /** @var array<string, Envelope[]> */
     private static array $queue = [];
 
-    /** @var array<string, self> */
-    private static array $transports = [];
-
-    private function __construct(string $name, MessageBusInterface $bus, SerializerInterface $serializer, array $options = [])
+    /**
+     * @internal
+     */
+    public function __construct(string $name, MessageBusInterface $bus, SerializerInterface $serializer, array $options = [])
     {
         $options = \array_merge(self::DEFAULT_OPTIONS, $options);
 
@@ -53,14 +53,6 @@ final class TestTransport implements TransportInterface
         $this->serializer = $serializer;
         $this->intercept = $options['intercept'];
         $this->catchExceptions = $options['catch_exceptions'];
-    }
-
-    /**
-     * @internal
-     */
-    public static function create(string $name, MessageBusInterface $bus, SerializerInterface $serializer, array $options = []): self
-    {
-        return self::$transports[$name] ??= new self($name, $bus, $serializer, $options);
     }
 
     /**
@@ -200,6 +192,6 @@ final class TestTransport implements TransportInterface
 
     public static function reset(): void
     {
-        self::$transports = self::$queue = self::$sent = self::$acknowledged = self::$rejected = [];
+        self::$queue = self::$sent = self::$acknowledged = self::$rejected = [];
     }
 }

--- a/src/Transport/TestTransportFactory.php
+++ b/src/Transport/TestTransportFactory.php
@@ -23,7 +23,7 @@ final class TestTransportFactory implements TransportFactoryInterface
 
     public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
     {
-        return TestTransport::create($options['transport_name'], $this->bus, $serializer, $this->parseDsn($dsn));
+        return new TestTransport($options['transport_name'], $this->bus, $serializer, $this->parseDsn($dsn));
     }
 
     public function supports(string $dsn, array $options): bool

--- a/src/Transport/TestTransportFactory.php
+++ b/src/Transport/TestTransportFactory.php
@@ -16,9 +16,6 @@ final class TestTransportFactory implements TransportFactoryInterface
 {
     private MessageBusInterface $bus;
 
-    /** @var array<string, self> */
-    private static array $transports = [];
-
     public function __construct(MessageBusInterface $bus)
     {
         $this->bus = $bus;
@@ -26,17 +23,12 @@ final class TestTransportFactory implements TransportFactoryInterface
 
     public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
     {
-        return self::$transports[$options['transport_name']] ??= new TestTransport($this->bus, $serializer, $this->parseDsn($dsn));
+        return TestTransport::create($options['transport_name'], $this->bus, $serializer, $this->parseDsn($dsn));
     }
 
     public function supports(string $dsn, array $options): bool
     {
         return 0 === \mb_strpos($dsn, 'test://');
-    }
-
-    public static function reset(): void
-    {
-        self::$transports = [];
     }
 
     private function parseDsn(string $dsn): array

--- a/tests/InteractsWithMessengerTest.php
+++ b/tests/InteractsWithMessengerTest.php
@@ -474,6 +474,49 @@ final class InteractsWithMessengerTest extends WebTestCase
         $this->messenger()->queue()->assertEmpty();
     }
 
+    /**
+     * @test
+     */
+    public function disabling_intercept_is_remembered_between_kernel_reboots(): void
+    {
+        self::bootKernel();
+
+        $this->messenger()->unblock();
+
+        self::$container->get(MessageBusInterface::class)->dispatch(new MessageA());
+
+        $this->messenger()->queue()->assertEmpty();
+        $this->messenger()->sent()->assertCount(1);
+
+        self::ensureKernelShutdown();
+        self::bootKernel();
+
+        self::$container->get(MessageBusInterface::class)->dispatch(new MessageA());
+
+        $this->messenger()->queue()->assertEmpty();
+        $this->messenger()->sent()->assertCount(2);
+    }
+
+    /**
+     * @test
+     */
+    public function throwing_exceptions_is_remembered_between_kernel_reboots(): void
+    {
+        self::bootKernel();
+
+        $this->messenger()->throwExceptions();
+
+        self::ensureKernelShutdown();
+        self::bootKernel();
+
+        self::$container->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectErrorMessage('handling failed...');
+
+        $this->messenger()->process();
+    }
+
     protected static function bootKernel(array $options = []): KernelInterface
     {
         return parent::bootKernel(\array_merge(['environment' => 'single_transport'], $options));

--- a/tests/InteractsWithMessengerTest.php
+++ b/tests/InteractsWithMessengerTest.php
@@ -512,7 +512,7 @@ final class InteractsWithMessengerTest extends WebTestCase
 
         $this->messenger()->queue()->assertNotEmpty();
 
-        $this->messenger()->reset();
+        $this->resetTransports();
 
         $this->messenger()->queue()->assertEmpty();
     }

--- a/tests/InteractsWithMessengerTest.php
+++ b/tests/InteractsWithMessengerTest.php
@@ -469,7 +469,7 @@ final class InteractsWithMessengerTest extends WebTestCase
 
         $this->messenger()->queue()->assertNotEmpty();
 
-        $this->resetTransports();
+        $this->messenger()->reset();
 
         $this->messenger()->queue()->assertEmpty();
     }

--- a/tests/InteractsWithMessengerTest.php
+++ b/tests/InteractsWithMessengerTest.php
@@ -116,29 +116,6 @@ final class InteractsWithMessengerTest extends WebTestCase
     /**
      * @test
      */
-    public function disabling_intercept_is_remembered_between_kernel_reboots(): void
-    {
-        self::bootKernel();
-
-        $this->messenger()->unblock();
-
-        self::$container->get(MessageBusInterface::class)->dispatch(new MessageA());
-
-        $this->messenger()->queue()->assertEmpty();
-        $this->messenger()->sent()->assertCount(1);
-
-        self::ensureKernelShutdown();
-        self::bootKernel();
-
-        self::$container->get(MessageBusInterface::class)->dispatch(new MessageA());
-
-        $this->messenger()->queue()->assertEmpty();
-        $this->messenger()->sent()->assertCount(2);
-    }
-
-    /**
-     * @test
-     */
     public function can_access_envelope_collection_items_via_first(): void
     {
         self::bootKernel();
@@ -433,26 +410,6 @@ final class InteractsWithMessengerTest extends WebTestCase
         self::$container->get(MessageBusInterface::class)->dispatch(new MessageB(true));
 
         $this->messenger('async2')->rejected()->assertCount(1);
-    }
-
-    /**
-     * @test
-     */
-    public function throwing_exceptions_is_remembered_between_kernel_reboots(): void
-    {
-        self::bootKernel();
-
-        $this->messenger()->throwExceptions();
-
-        self::ensureKernelShutdown();
-        self::bootKernel();
-
-        self::$container->get(MessageBusInterface::class)->dispatch(new MessageA(true));
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectErrorMessage('handling failed...');
-
-        $this->messenger()->process();
     }
 
     /**


### PR DESCRIPTION
The implementation in #8 introduced a major bug (see #9 for details). This is an alternate implementation:

- [BC BREAK] `TestTransport::reset()` is no longer static - it is now an instance method and resets just that instance's data (not config).
- [feature] added static `TestTransport::resetAll()` method that resets all test transport data and config.

_(Fixes #7, Fixes #9)_