### PR TITLE
[BC BREAK] make TestTransport::process() recursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ class MyTest extends KernelTestCase // or WebTestCase
 }
 ```
 
+**NOTE:** Calling `process()` not only processes messages on the queue but any
+messages created during the handling of messages (all by default or up to `$number`).
+
 ### Other Transport Assertions and Helpers
 
 ```php

--- a/tests/Fixture/Messenger/MessageD.php
+++ b/tests/Fixture/Messenger/MessageD.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Zenstruck\Messenger\Test\Tests\Fixture\Messenger;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class MessageD
+{
+}

--- a/tests/Fixture/Messenger/MessageDHandler.php
+++ b/tests/Fixture/Messenger/MessageDHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Zenstruck\Messenger\Test\Tests\Fixture\Messenger;
+
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class MessageDHandler implements MessageHandlerInterface
+{
+    private MessageBusInterface $bus;
+
+    public function __construct(MessageBusInterface $bus)
+    {
+        $this->bus = $bus;
+    }
+
+    public function __invoke(MessageD $message): void
+    {
+        $this->bus->dispatch(new MessageE());
+    }
+}

--- a/tests/Fixture/Messenger/MessageE.php
+++ b/tests/Fixture/Messenger/MessageE.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Zenstruck\Messenger\Test\Tests\Fixture\Messenger;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class MessageE
+{
+}

--- a/tests/Fixture/Messenger/MessageEHandler.php
+++ b/tests/Fixture/Messenger/MessageEHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Zenstruck\Messenger\Test\Tests\Fixture\Messenger;
+
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class MessageEHandler implements MessageHandlerInterface
+{
+    private MessageBusInterface $bus;
+
+    public function __construct(MessageBusInterface $bus)
+    {
+        $this->bus = $bus;
+    }
+
+    public function __invoke(MessageE $message): void
+    {
+        $this->bus->dispatch(new MessageF());
+    }
+}

--- a/tests/Fixture/Messenger/MessageF.php
+++ b/tests/Fixture/Messenger/MessageF.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Zenstruck\Messenger\Test\Tests\Fixture\Messenger;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class MessageF
+{
+}

--- a/tests/Fixture/Messenger/MessageFHandler.php
+++ b/tests/Fixture/Messenger/MessageFHandler.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Zenstruck\Messenger\Test\Tests\Fixture\Messenger;
+
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class MessageFHandler implements MessageHandlerInterface
+{
+    public function __invoke(MessageF $message): void
+    {
+    }
+}

--- a/tests/Fixture/config/single_transport.yaml
+++ b/tests/Fixture/config/single_transport.yaml
@@ -8,3 +8,6 @@ framework:
         routing:
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async]
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageB: [async]
+            Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageD: [async]
+            Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageE: [async]
+            Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageF: [async]

--- a/tests/Fixture/config/test.yaml
+++ b/tests/Fixture/config/test.yaml
@@ -7,6 +7,9 @@ services:
     Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageAHandler: ~
     Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageBHandler: ~
     Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageCHandler: ~
+    Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageDHandler: ~
+    Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageEHandler: ~
+    Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageFHandler: ~
 
     message_bus:
         alias: Symfony\Component\Messenger\MessageBusInterface


### PR DESCRIPTION
and fail if no messages to process. Closes #10.