### PR TITLE
Add `EnvelopeCollection::back()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Zenstruck\Messenger\Test\InteractsWithMessenger;
+use Zenstruck\Messenger\Test\Transport\TestTransport;
 
 class MyTest extends KernelTestCase // or WebTestCase
 {
@@ -155,6 +156,29 @@ class MyTest extends KernelTestCase // or WebTestCase
         // TestEnvelope stamp assertions
         $queue->first()->assertHasStamp(DelayStamp::class);
         $queue->first()->assertNotHasStamp(DelayStamp::class);
+
+        // reset collected messages on the transport
+        $this->messenger()->reset();
+
+        // reset collected messages for all transports
+        TestTransport::resetAll();
+
+        // fluid assertions on different EnvelopeCollections
+        $this->messenger()
+            ->queue()
+                ->assertNotEmpty()
+                ->assertContains(MyMessage::class)
+            ->back() // returns to the TestTransport
+            ->dispatched()
+                ->assertEmpty()
+            ->back()
+            ->acknowledged()
+                ->assertEmpty()
+            ->back()
+            ->rejected()
+                ->assertEmpty()
+            ->back()
+        ;
     }
 }
 ```

--- a/src/EnvelopeCollection.php
+++ b/src/EnvelopeCollection.php
@@ -4,20 +4,28 @@ namespace Zenstruck\Messenger\Test;
 
 use Symfony\Component\Messenger\Envelope;
 use Zenstruck\Assert;
+use Zenstruck\Messenger\Test\Transport\TestTransport;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 final class EnvelopeCollection implements \IteratorAggregate, \Countable
 {
+    private TestTransport $transport;
     private array $envelopes;
 
     /**
      * @internal
      */
-    public function __construct(Envelope ...$envelopes)
+    public function __construct(TestTransport $transport, Envelope ...$envelopes)
     {
+        $this->transport = $transport;
         $this->envelopes = $envelopes;
+    }
+
+    public function back(): TestTransport
+    {
+        return $this->transport;
     }
 
     public function assertEmpty(): self

--- a/src/Transport/TestTransport.php
+++ b/src/Transport/TestTransport.php
@@ -179,22 +179,22 @@ final class TestTransport implements TransportInterface
 
     public function queue(): EnvelopeCollection
     {
-        return new EnvelopeCollection(...\array_values(self::$queue[$this->name] ?? []));
+        return new EnvelopeCollection($this, ...\array_values(self::$queue[$this->name] ?? []));
     }
 
     public function dispatched(): EnvelopeCollection
     {
-        return new EnvelopeCollection(...self::$dispatched[$this->name] ?? []);
+        return new EnvelopeCollection($this, ...self::$dispatched[$this->name] ?? []);
     }
 
     public function acknowledged(): EnvelopeCollection
     {
-        return new EnvelopeCollection(...self::$acknowledged[$this->name] ?? []);
+        return new EnvelopeCollection($this, ...self::$acknowledged[$this->name] ?? []);
     }
 
     public function rejected(): EnvelopeCollection
     {
-        return new EnvelopeCollection(...self::$rejected[$this->name] ?? []);
+        return new EnvelopeCollection($this, ...self::$rejected[$this->name] ?? []);
     }
 
     /**

--- a/tests/InteractsWithMessengerTest.php
+++ b/tests/InteractsWithMessengerTest.php
@@ -75,6 +75,35 @@ final class InteractsWithMessengerTest extends WebTestCase
     /**
      * @test
      */
+    public function can_use_envelope_collection_back(): void
+    {
+        self::bootKernel();
+
+        $this->messenger()
+            ->queue()->assertEmpty()->back()
+            ->dispatched()->assertEmpty()->back()
+            ->acknowledged()->assertEmpty()->back()
+            ->rejected()->assertEmpty()
+        ;
+
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA());
+
+        $this->messenger()
+            ->queue()->assertCount(1)->back()
+            ->dispatched()->assertCount(1)->back()
+            ->acknowledged()->assertEmpty()->back()
+            ->rejected()->assertEmpty()->back()
+            ->process()
+            ->queue()->assertEmpty()->back()
+            ->dispatched()->assertCount(1)->back()
+            ->acknowledged()->assertCount(1)->back()
+            ->rejected()->assertEmpty()->back()
+        ;
+    }
+
+    /**
+     * @test
+     */
     public function can_disable_intercept(): void
     {
         self::bootKernel();


### PR DESCRIPTION
Allows making assertions on multiple collections in a fluid way:

```php
$this->messenger()
    ->queue()
        ->assertNotEmpty()
        ->assertContains(MyMessage::class)
    ->back() // returns to the TestTransport
    ->dispatched()
        ->assertEmpty()
    ->back()
    ->acknowledged()
        ->assertEmpty()
    ->back()
    ->rejected()
        ->assertEmpty()
    ->back()
;
```