### PR TITLE
[minor] give a name to the transport in the Worker

### DIFF
--- a/src/Transport/TestTransport.php
+++ b/src/Transport/TestTransport.php
@@ -151,7 +151,7 @@ final class TestTransport implements TransportInterface
             );
         }
 
-        $worker = new Worker([$this], $this->bus, $this->dispatcher);
+        $worker = new Worker([$this->name => $this], $this->bus, $this->dispatcher);
         $worker->run(['sleep' => 0]);
 
         // remove added listeners/subscribers

--- a/tests/Fixture/config/multi_transport.yaml
+++ b/tests/Fixture/config/multi_transport.yaml
@@ -4,8 +4,14 @@ imports:
 framework:
     messenger:
         transports:
-            async1: test://
-            async2: test://?intercept=false&catch_exceptions=false&test_serialization=false
+            async1:
+                dsn: test://
+                retry_strategy:
+                    max_retries: 0
+            async2:
+                dsn: test://?intercept=false&catch_exceptions=false&test_serialization=false
+                retry_strategy:
+                    max_retries: 0
             async3: in-memory://
         routing:
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async1]

--- a/tests/Fixture/config/single_transport.yaml
+++ b/tests/Fixture/config/single_transport.yaml
@@ -4,7 +4,10 @@ imports:
 framework:
     messenger:
         transports:
-            async: test://
+            async:
+                dsn: test://
+                retry_strategy:
+                    max_retries: 0
         routing:
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async]
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageB: [async]


### PR DESCRIPTION
Hello!

I hope this was not made on purpose, but in order to best mimic the behavior of messenger, the receivers need to have a name in the worker, as seen in [`Symfony\Component\Messenger\Command\ConsumeMessagesCommand`](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php#L216)

```php
// Symfony\Component\Messenger\Command\ConsumeMessagesCommand
protected function execute(InputInterface $input, OutputInterface $output): int
{
        $receivers = [];
        foreach ($receiverNames = $input->getArgument('receivers') as $receiverName) {
            //...
            $receivers[$receiverName] = $this->receiverLocator->get($receiverName);
        }

        // ...
        $worker = new Worker($receivers, $bus, $this->eventDispatcher, $this->logger);
        // ...
}
```

Otherwise, we cannot reproduce the retry behavior because the [computation of `retryStrategy` is based on transport's name](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php#L52). Yet, IMO, it could be a good thing to be able to reproduce retry behavior in tests since I've already had some complex bugs in retry scenario.