### PR TITLE
[fix] prevent infinite loop in unblock mode (#32)

### DIFF
--- a/src/Transport/TestTransport.php
+++ b/src/Transport/TestTransport.php
@@ -179,7 +179,7 @@ final class TestTransport implements TransportInterface
 
     public function queue(): EnvelopeCollection
     {
-        return new EnvelopeCollection($this, ...\array_values(self::$queue[$this->name] ?? []));
+        return new EnvelopeCollection($this, ...self::$queue[$this->name] ?? []);
     }
 
     public function dispatched(): EnvelopeCollection
@@ -202,7 +202,7 @@ final class TestTransport implements TransportInterface
      */
     public function get(): iterable
     {
-        return \array_values(self::$queue[$this->name] ?? []);
+        return self::$queue[$this->name] ? [\array_shift(self::$queue[$this->name])] : [];
     }
 
     /**
@@ -211,7 +211,6 @@ final class TestTransport implements TransportInterface
     public function ack(Envelope $envelope): void
     {
         self::$acknowledged[$this->name][] = $envelope;
-        unset(self::$queue[$this->name][\spl_object_hash($envelope->getMessage())]);
     }
 
     /**
@@ -220,7 +219,6 @@ final class TestTransport implements TransportInterface
     public function reject(Envelope $envelope): void
     {
         self::$rejected[$this->name][] = $envelope;
-        unset(self::$queue[$this->name][\spl_object_hash($envelope->getMessage())]);
     }
 
     public function send(Envelope $envelope): Envelope
@@ -229,7 +227,7 @@ final class TestTransport implements TransportInterface
         $this->serializer->decode($this->serializer->encode($envelope));
 
         self::$dispatched[$this->name][] = $envelope;
-        self::$queue[$this->name][\spl_object_hash($envelope->getMessage())] = $envelope;
+        self::$queue[$this->name][] = $envelope;
 
         if (!$this->isIntercepting()) {
             $this->process();

--- a/tests/InteractsWithMessengerTest.php
+++ b/tests/InteractsWithMessengerTest.php
@@ -651,6 +651,22 @@ final class InteractsWithMessengerTest extends WebTestCase
     /**
      * @test
      */
+    public function process_x_recursive_when_intercept_disabled(): void
+    {
+        self::bootKernel();
+
+        $this->messenger()->unblock();
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageD());
+
+        $this->messenger()->acknowledged()->assertCount(3);
+        $this->messenger()->acknowledged()->assertContains(MessageD::class, 1);
+        $this->messenger()->acknowledged()->assertContains(MessageE::class, 1);
+        $this->messenger()->acknowledged()->assertContains(MessageF::class, 1);
+    }
+
+    /**
+     * @test
+     */
     public function fails_if_trying_to_process_more_messages_than_can_be_processed(): void
     {
         self::bootKernel();


### PR DESCRIPTION
closes #32 

A better solution was to send envelopes one by one from `TestTransport::get()` and directly remove them from `self::$queue[$name]` in the `get()` method. Somehow I think we're closer from the real mechanism since when a message is passed to the worker it's removed from the queue.

BTW if you remove the fix, the test `process_x_recursive_when_intercept_disabled()` creates an infinite loop. This behavior wasn't caught by the tests because other tests which uses `unblock()` do not dispatch messages "D" or "E" which are not only ones which are recursive.

