### PR TITLE
Disable retries by default, add option to enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,10 +268,10 @@ framework:
             async: test://?intercept=false
 ```
 
-### Testing serialization
+### Testing Serialization
 
-By default, the bundle tests if the envelopes could be serialized and deserialized.
-This behavior can be disabled at transport level:
+By default, the `TestTransport` tests that messages can be serialized and deserialized.
+This behavior can be disabled with the transport dsn:
 
 ```yaml
 # config/packages/test/messenger.yaml
@@ -280,6 +280,20 @@ framework:
     messenger:
         transports:
             async: test://?test_serialization=false
+```
+
+### Enable Retries
+
+By default, the `TestTransport` does not retry failed messages (your retry settings
+are ignored). This behavior can be disabled with the transport dsn:
+
+```yaml
+# config/packages/test/messenger.yaml
+
+framework:
+    messenger:
+        transports:
+            async: test://?disable_retries=false
 ```
 
 ### Multiple Transports

--- a/src/Transport/TestTransportFactory.php
+++ b/src/Transport/TestTransportFactory.php
@@ -46,6 +46,7 @@ final class TestTransportFactory implements TransportFactoryInterface
             'intercept' => \filter_var($query['intercept'] ?? true, \FILTER_VALIDATE_BOOLEAN),
             'catch_exceptions' => \filter_var($query['catch_exceptions'] ?? true, \FILTER_VALIDATE_BOOLEAN),
             'test_serialization' => \filter_var($query['test_serialization'] ?? true, \FILTER_VALIDATE_BOOLEAN),
+            'disable_retries' => \filter_var($query['disable_retries'] ?? true, \FILTER_VALIDATE_BOOLEAN),
         ];
     }
 }

--- a/tests/Fixture/config/multi_transport.yaml
+++ b/tests/Fixture/config/multi_transport.yaml
@@ -6,12 +6,8 @@ framework:
         transports:
             async1:
                 dsn: test://
-                retry_strategy:
-                    max_retries: 0
             async2:
                 dsn: test://?intercept=false&catch_exceptions=false&test_serialization=false
-                retry_strategy:
-                    max_retries: 0
             async3: in-memory://
         routing:
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async1]

--- a/tests/Fixture/config/multi_transport.yaml
+++ b/tests/Fixture/config/multi_transport.yaml
@@ -9,7 +9,9 @@ framework:
             async2:
                 dsn: test://?intercept=false&catch_exceptions=false&test_serialization=false
             async3: in-memory://
+            async4:
+                dsn: test://?disable_retries=false
         routing:
-            Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async1]
+            Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async1, async4]
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageB: [async2]
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageG: [async2]

--- a/tests/Fixture/config/single_transport.yaml
+++ b/tests/Fixture/config/single_transport.yaml
@@ -6,8 +6,6 @@ framework:
         transports:
             async:
                 dsn: test://
-                retry_strategy:
-                    max_retries: 0
         routing:
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async]
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageB: [async]

--- a/tests/InteractsWithMessengerTest.php
+++ b/tests/InteractsWithMessengerTest.php
@@ -336,7 +336,7 @@ final class InteractsWithMessengerTest extends WebTestCase
         self::bootKernel(['environment' => 'multi_transport']);
 
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Multiple transports are registered (async1, async2, async3), you must specify a name.');
+        $this->expectExceptionMessage('Multiple transports are registered (async1, async2, async3, async4), you must specify a name.');
 
         $this->messenger();
     }
@@ -779,6 +779,22 @@ final class InteractsWithMessengerTest extends WebTestCase
         ;
 
         Assert::run(fn() => $this->messenger('async2')->send(new Envelope(new MessageG())));
+    }
+
+    /**
+     * @test
+     */
+    public function can_enable_retries(): void
+    {
+        self::bootKernel(['environment' => 'multi_transport']);
+
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+
+        $this->messenger('async4')
+            ->process()
+            ->rejected()
+            ->assertContains(MessageA::class, 4)
+        ;
     }
 
     protected static function bootKernel(array $options = []): KernelInterface


### PR DESCRIPTION
1381f279dc4b07c475474113fa086606704319af fixes a BC break introduced in #34. That PR fixed an issue where the transport names were not being properly registered with the Worker. This enabled the retry system but broke code that was not expecting retries to be made.

8a434ad5b3f2e8abdd5516d86f0339cb2a598adc adds the ability to enable retries for your test transports (via dsn config). I believe this was @nikophil's original intention with #34.