### PR TITLE
Allow `TestTransport::send()` to accept `object|array`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -43,6 +43,16 @@ return $config
         'phpdoc_to_comment' => false,
         'function_declaration' => ['closure_function_spacing' => 'none'],
         'nullable_type_declaration_for_default_null_value' => true,
+        'phpdoc_separation' => ['groups' => [
+            ['test', 'dataProvider'],
+            ['before', 'after'],
+            ['template', 'implements', 'extends'],
+            ['phpstan-type', 'phpstan-import-type'],
+            ['deprecated', 'link', 'see', 'since'],
+            ['author', 'copyright', 'license', 'source'],
+            ['category', 'package', 'subpackage'],
+            ['property', 'property-read', 'property-write'],
+        ]],
     ])
     ->setRiskyAllowed(true)
     ->setFinder($finder)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,13 @@ class MyTest extends KernelTestCase // or WebTestCase
     public function test_something(): void
     {
         // manually send a message to your transport
-        $this->messenger()->send(Envelope::wrap(new MyMessage()));
+        $this->messenger()->send(new MyMessage());
+
+        // send with stamps
+        $this->messenger()->send(Envelope::wrap(new MyMessage(), [new SomeStamp()]));
+
+        // send "pre-encoded" message
+        $this->messenger()->send(['body' => '...']);
 
         $queue = $this->messenger()->queue();
         $dispatched = $this->messenger()->dispatched();

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,24 +2,3 @@ parameters:
     level: 8
     paths:
         - src
-        - tests
-    ignoreErrors:
-        # This is expected as NonKernelTestCaseTest does not extend KernelTestCase
-        - '#undefined static property|method Zenstruck\\Messenger\\Test\\Tests\\NonKernelTestCaseTest#'
-
-        # Symfony container-related
-        - message: "#^Cannot call method dispatch\\(\\) on object\\|null\\.$#"
-          count: 1
-          path: tests/Fixture/Kernel.php
-        - message: "#^Access to an undefined property object\\:\\:\\$fail\\.$#"
-          count: 1
-          path: tests/InteractsWithMessengerTest.php
-        - message: "#^Cannot access property \\$messages on object\\|null\\.$#"
-          count: 24
-          path: tests/InteractsWithMessengerTest.php
-        - message: "#^Cannot call method addListener\\(\\) on object\\|null\\.$#"
-          count: 1
-          path: tests/InteractsWithMessengerTest.php
-        - message: "#^Cannot call method dispatch\\(\\) on object\\|null\\.$#"
-          count: 48
-          path: tests/InteractsWithMessengerTest.php

--- a/src/InteractsWithMessenger.php
+++ b/src/InteractsWithMessenger.php
@@ -13,6 +13,7 @@ trait InteractsWithMessenger
 {
     /**
      * @internal
+     *
      * @before
      * @after
      */


### PR DESCRIPTION
This makes it easier to send a message with no stamps (removes the requirement for wrapping in an envelope). Additionally, allows sending a "pre-encoded" message array.

Closes #49.