### PR TITLE
[Fix] ignore receiver detached from transport

### DIFF
--- a/src/ZenstruckMessengerTestBundle.php
+++ b/src/ZenstruckMessengerTestBundle.php
@@ -7,6 +7,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\Messenger\Transport\TransportInterface;
 use Zenstruck\Messenger\Test\Transport\TestTransportFactory;
 use Zenstruck\Messenger\Test\Transport\TestTransportRegistry;
 
@@ -40,6 +41,15 @@ final class ZenstruckMessengerTestBundle extends Bundle implements CompilerPassI
 
         foreach ($container->findTaggedServiceIds('messenger.receiver') as $id => $tags) {
             $name = $id;
+
+            $class = $container->getDefinition($name)->getClass();
+            if (!$class) {
+                continue;
+            }
+
+            if (!\is_a($class, TransportInterface::class, true)) {
+                continue;
+            }
 
             foreach ($tags as $tag) {
                 if (isset($tag['alias'])) {

--- a/src/ZenstruckMessengerTestBundle.php
+++ b/src/ZenstruckMessengerTestBundle.php
@@ -42,8 +42,7 @@ final class ZenstruckMessengerTestBundle extends Bundle implements CompilerPassI
         foreach ($container->findTaggedServiceIds('messenger.receiver') as $id => $tags) {
             $name = $id;
 
-            $class = $container->getDefinition($name)->getClass();
-            if (!$class) {
+            if (!$class = $container->getDefinition($name)->getClass()) {
                 continue;
             }
 

--- a/tests/Fixture/Messenger/Receiver/RandomReceiver.php
+++ b/tests/Fixture/Messenger/Receiver/RandomReceiver.php
@@ -3,7 +3,6 @@
 namespace Zenstruck\Messenger\Test\Tests\Fixture\Messenger\Receiver;
 
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 
 class RandomReceiver implements ReceiverInterface

--- a/tests/Fixture/Messenger/Receiver/RandomReceiver.php
+++ b/tests/Fixture/Messenger/Receiver/RandomReceiver.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Zenstruck\Messenger\Test\Tests\Fixture\Messenger\Receiver;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+
+class RandomReceiver implements ReceiverInterface
+{
+    /**
+     * @return Envelope[]
+     *
+     * @throws TransportException
+     */
+    public function get(): iterable
+    {
+        yield;
+    }
+
+    /**
+     * @throws TransportException
+     */
+    public function ack(Envelope $envelope): void
+    {
+    }
+
+    /**
+     * @throws TransportException
+     */
+    public function reject(Envelope $envelope): void
+    {
+    }
+}

--- a/tests/Fixture/Messenger/Receiver/RandomReceiver.php
+++ b/tests/Fixture/Messenger/Receiver/RandomReceiver.php
@@ -8,26 +8,15 @@ use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 
 class RandomReceiver implements ReceiverInterface
 {
-    /**
-     * @return Envelope[]
-     *
-     * @throws TransportException
-     */
     public function get(): iterable
     {
         yield;
     }
 
-    /**
-     * @throws TransportException
-     */
     public function ack(Envelope $envelope): void
     {
     }
 
-    /**
-     * @throws TransportException
-     */
     public function reject(Envelope $envelope): void
     {
     }

--- a/tests/Fixture/config/with_receiver_detached.yaml
+++ b/tests/Fixture/config/with_receiver_detached.yaml
@@ -1,0 +1,8 @@
+imports:
+    - { resource: test.yaml }
+    - { resource: single_transport.yaml }
+
+services:
+    Zenstruck\Messenger\Test\Tests\Fixture\Messenger\Receiver\RandomReceiver:
+        tags:
+            - { name: messenger.receiver }

--- a/tests/InteractsWithMessengerTest.php
+++ b/tests/InteractsWithMessengerTest.php
@@ -25,6 +25,7 @@ use Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageE;
 use Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageF;
 use Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageG;
 use Zenstruck\Messenger\Test\Tests\Fixture\NoBundleKernel;
+use Zenstruck\Messenger\Test\Transport\TestTransport;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -32,6 +33,17 @@ use Zenstruck\Messenger\Test\Tests\Fixture\NoBundleKernel;
 final class InteractsWithMessengerTest extends WebTestCase
 {
     use InteractsWithMessenger;
+
+    /**
+     * @test
+     */
+    public function ignore_receiver_detached_from_transport(): void
+    {
+        self::bootKernel(['environment' => 'with_receiver_detached']);
+
+        $transport = $this->messenger();
+        $this->assertInstanceOf(TestTransport::class, $transport);
+    }
 
     /**
      * @test


### PR DESCRIPTION
Hello,

Issue explained here: #51 

summary: In case there are transports (single or multiple) but also classes implementing ReceiverInterface without being attached to a transport, the registration of "the transport" is prevented because it implements receiverInterface but not transportInterface.

Proposal: Check if's a TransportInterface before calling register of testTransportRegistry


