### PR TITLE
feat: enable messages collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: zenstruck/.github@php-cs-fixer
         with:
-          php: 7.4
+          php: 8.0
           key: ${{ secrets.GPG_PRIVATE_KEY }}
           token: ${{ secrets.COMPOSER_TOKEN }}
 

--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,17 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
-        "symfony/framework-bundle": "^4.4|^5.0|^6.0",
-        "symfony/messenger": "^4.4|^5.0|^6.0",
+        "php": ">=8.0",
+        "symfony/framework-bundle": "^5.4|^6.0",
+        "symfony/messenger": "^5.4|^6.0",
         "zenstruck/assert": "^1.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^9.5.0",
-        "symfony/browser-kit": "^4.4|^5.0|^6.0",
-        "symfony/phpunit-bridge": "^5.3",
-        "symfony/yaml": "^4.4|^5.0|^6.0"
+        "symfony/browser-kit": "^5.4|^6.0",
+        "symfony/phpunit-bridge": "^5.4|^6.0",
+        "symfony/yaml": "^5.4|^6.0"
     },
     "config": {
         "preferred-install": "dist",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,11 @@
     <testsuites>
         <testsuite name="zenstruck/messenger-test Test Suite">
             <directory>./tests/</directory>
+            <exclude>./tests/TransportsAreResetCorrectly</exclude>
+        </testsuite>
+        <testsuite name="zenstruck/messenger-test transports are reset correctly">
+            <file>./tests/TransportsAreResetCorrectly/NotInteractsWithMessengerTest.php</file>
+            <file>./tests/TransportsAreResetCorrectly/AfterNotInteractsWithMessengerTest.php</file>
         </testsuite>
     </testsuites>
 

--- a/src/InteractsWithMessenger.php
+++ b/src/InteractsWithMessenger.php
@@ -24,6 +24,25 @@ trait InteractsWithMessenger
      * @internal
      *
      * @before
+     */
+    final protected static function _enableMessagesCollection(): void
+    {
+        TestTransport::enableMessagesCollection();
+    }
+
+    /**
+     * @internal
+     *
+     * @after
+     */
+    final protected static function _disableMessagesCollection(): void
+    {
+        TestTransport::disableMessagesCollection();
+    }
+
+    /**
+     * @internal
+     *
      * @after
      */
     final protected static function _resetMessengerTransports(): void

--- a/tests/TransportsAreResetCorrectly/AfterNotInteractsWithMessengerTest.php
+++ b/tests/TransportsAreResetCorrectly/AfterNotInteractsWithMessengerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-test package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Test\Tests\TransportsAreResetCorrectly;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Zenstruck\Messenger\Test\InteractsWithMessenger;
+
+/**
+ * This test runs after NotInteractsWithMessengerTest and asserts the message dispatched there, without using InteractsWithMessenger
+ * is not present anymore in the test transport.
+ */
+final class AfterNotInteractsWithMessengerTest extends KernelTestCase
+{
+    use InteractsWithMessenger;
+
+    /**
+     * @test
+     */
+    public function assert_transports_are_reset_after_a_test_which_does_not_use_trait(): void
+    {
+        self::bootKernel();
+
+        $this->messenger()->queue()->assertCount(0);
+        $this->messenger()->dispatched()->assertCount(0);
+        $this->messenger()->acknowledged()->assertCount(0);
+        $this->messenger()->rejected()->assertCount(0);
+    }
+
+    protected static function bootKernel(array $options = []): KernelInterface // @phpstan-ignore-line
+    {
+        return parent::bootKernel(\array_merge(['environment' => 'single_transport'], $options));
+    }
+}

--- a/tests/TransportsAreResetCorrectly/NotInteractsWithMessengerTest.php
+++ b/tests/TransportsAreResetCorrectly/NotInteractsWithMessengerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-test package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Test\Tests\TransportsAreResetCorrectly;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA;
+use Zenstruck\Messenger\Test\Transport\TestTransportRegistry;
+
+/**
+ * This test is just made to dispatch a message without using "InteractsWithMessenger" trait.
+ * We want to confirm that the next test starts with empty transports.
+ */
+final class NotInteractsWithMessengerTest extends KernelTestCase
+{
+    public function test_it_dispatches_a_message(): void
+    {
+        /** @var TestTransportRegistry $registry */
+        $registry = self::getContainer()->get('zenstruck_messenger_test.transport_registry');
+        $testTransport = $registry->get();
+
+        $testTransport->queue()->assertCount(0);
+
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA());
+
+        $testTransport->queue()->assertCount(0);
+    }
+
+    protected static function bootKernel(array $options = []): KernelInterface // @phpstan-ignore-line
+    {
+        return parent::bootKernel(\array_merge(['environment' => 'single_transport'], $options));
+    }
+}


### PR DESCRIPTION
fixes #24

this also fixes a BC break #40 introduced

first, this PR adds tests for the original problem #40 fixed in order to not validate there is no regression on this topic. This is the main purpose of both classes in `Zenstruck\Messenger\Test\Tests\TransportsAreResetCorrectly` and the new test suite in `phpunit.xml`. I had to ensure a test without the trait runs directly before `assert_transports_are_reset_after_a_test_which_does_not_use_trait()`

EDIT: because I had some errors in CI due to sf 4.4, I've modified minimum req for php and Symfony :innocent: 