### PR TITLE
fix(EnvelopeCollection): return type for psalm and method final

### DIFF
--- a/src/EnvelopeCollection.php
+++ b/src/EnvelopeCollection.php
@@ -32,26 +32,26 @@ abstract class EnvelopeCollection implements \IteratorAggregate, \Countable
         $this->envelopes = $envelopes;
     }
 
-    public function assertEmpty(): static
+    final public function assertEmpty(): static
     {
         return $this->assertCount(0);
     }
 
-    public function assertNotEmpty(): static
+    final public function assertNotEmpty(): static
     {
         Assert::that($this)->isNotEmpty('Expected some messages but found none.');
 
         return $this;
     }
 
-    public function assertCount(int $count): static
+    final public function assertCount(int $count): static
     {
         Assert::that($this->envelopes)->hasCount($count, 'Expected {expected} messages but {actual} messages found.');
 
         return $this;
     }
 
-    public function assertContains(string $messageClass, ?int $times = null): static
+    final public function assertContains(string $messageClass, ?int $times = null): static
     {
         $messages = $this->messages($messageClass);
 
@@ -70,7 +70,7 @@ abstract class EnvelopeCollection implements \IteratorAggregate, \Countable
         return $this;
     }
 
-    public function assertNotContains(string $messageClass): static
+    final public function assertNotContains(string $messageClass): static
     {
         Assert::that($this->messages($messageClass))->isEmpty(
             'Found message "{message}" but should not.',

--- a/src/EnvelopeCollection.php
+++ b/src/EnvelopeCollection.php
@@ -32,26 +32,26 @@ abstract class EnvelopeCollection implements \IteratorAggregate, \Countable
         $this->envelopes = $envelopes;
     }
 
-    public function assertEmpty(): self
+    public function assertEmpty(): static
     {
         return $this->assertCount(0);
     }
 
-    public function assertNotEmpty(): self
+    public function assertNotEmpty(): static
     {
         Assert::that($this)->isNotEmpty('Expected some messages but found none.');
 
         return $this;
     }
 
-    public function assertCount(int $count): self
+    public function assertCount(int $count): static
     {
         Assert::that($this->envelopes)->hasCount($count, 'Expected {expected} messages but {actual} messages found.');
 
         return $this;
     }
 
-    public function assertContains(string $messageClass, ?int $times = null): self
+    public function assertContains(string $messageClass, ?int $times = null): static
     {
         $messages = $this->messages($messageClass);
 
@@ -70,7 +70,7 @@ abstract class EnvelopeCollection implements \IteratorAggregate, \Countable
         return $this;
     }
 
-    public function assertNotContains(string $messageClass): self
+    public function assertNotContains(string $messageClass): static
     {
         Assert::that($this->messages($messageClass))->isEmpty(
             'Found message "{message}" but should not.',

--- a/src/EnvelopeCollection.php
+++ b/src/EnvelopeCollection.php
@@ -83,7 +83,7 @@ abstract class EnvelopeCollection implements \IteratorAggregate, \Countable
     /**
      * @param string|callable|null $filter
      */
-    public function first($filter = null): TestEnvelope
+    final public function first($filter = null): TestEnvelope
     {
         if (null === $filter) {
             // just the first envelope
@@ -113,7 +113,7 @@ abstract class EnvelopeCollection implements \IteratorAggregate, \Countable
      *
      * @return object[]
      */
-    public function messages(?string $class = null): array
+    final public function messages(?string $class = null): array
     {
         $messages = \array_map(static fn(Envelope $envelope) => $envelope->getMessage(), $this->envelopes);
 
@@ -127,7 +127,7 @@ abstract class EnvelopeCollection implements \IteratorAggregate, \Countable
     /**
      * @return TestEnvelope[]
      */
-    public function all(): array
+    final public function all(): array
     {
         return \iterator_to_array($this);
     }
@@ -135,14 +135,14 @@ abstract class EnvelopeCollection implements \IteratorAggregate, \Countable
     /**
      * @return \Traversable|TestEnvelope[]
      */
-    public function getIterator(): \Traversable
+    final public function getIterator(): \Traversable
     {
         foreach ($this->envelopes as $envelope) {
             yield new TestEnvelope($envelope);
         }
     }
 
-    public function count(): int
+    final public function count(): int
     {
         return \count($this->envelopes);
     }


### PR DESCRIPTION
@nikophil I make all public method as final.

The class was final before my changes. As the `EnvelopeCollection` is now extended we need to make each of the public method final.

related to #59 

Thanks :-)