### PR TITLE
feat: support delay stamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,23 @@ on:
 
 jobs:
   test:
-    uses: zenstruck/.github/.github/workflows/php-test-symfony.yml@main
+    name: PHP ${{ matrix.php }}, SF ${{ matrix.symfony }} - ${{ matrix.deps }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [8.1, 8.2, 8.3]
+        deps: [highest]
+        symfony: [5.4.*, 6.3.*, 6.4.*]
+        include:
+          - php: 8.1
+            deps: lowest
+            symfony: '*'
+    steps:
+      - uses: zenstruck/.github@php-test-symfony
+        with:
+          php: ${{ matrix.php }}
+          symfony: ${{ matrix.symfony }}
+          deps: ${{ matrix.deps }}
 
   code-coverage:
     uses: zenstruck/.github/.github/workflows/php-coverage-codecov.yml@main

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "symfony/deprecation-contracts": "^2.2|^3.0",
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/messenger": "^5.4|^6.0",
@@ -22,8 +22,12 @@
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^9.5.0",
         "symfony/browser-kit": "^5.4|^6.0",
+        "symfony/clock": "^6.3",
         "symfony/phpunit-bridge": "^5.4|^6.0",
         "symfony/yaml": "^5.4|^6.0"
+    },
+    "suggest": {
+        "symfony/clock": "A PSR-20 clock implementation in order to support DelayStamp."
     },
     "config": {
         "preferred-install": "dist",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^1.4",
-        "phpunit/phpunit": "^9.5.0",
+        "phpunit/phpunit": "^9.6.0",
         "symfony/browser-kit": "^5.4|^6.0",
         "symfony/clock": "^6.3",
         "symfony/phpunit-bridge": "^5.4|^6.0",

--- a/src/Stamp/AvailableAtStamp.php
+++ b/src/Stamp/AvailableAtStamp.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Messenger\Test\Stamp;
+
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+final class AvailableAtStamp implements StampInterface
+{
+    public function __construct(private \DateTimeImmutable $availableAt)
+    {
+    }
+
+    public static function fromDelayStamp(DelayStamp $delayStamp, \DateTimeImmutable $now): self
+    {
+        return new self(
+            $now->modify(sprintf('+%d seconds', $delayStamp->getDelay() / 1000))
+        );
+    }
+
+    public function getAvailableAt(): \DateTimeImmutable
+    {
+        return $this->availableAt;
+    }
+}

--- a/src/Stamp/AvailableAtStamp.php
+++ b/src/Stamp/AvailableAtStamp.php
@@ -1,12 +1,14 @@
 <?php
 
-declare(strict_types=1);
 
 namespace Zenstruck\Messenger\Test\Stamp;
 
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
+/**
+ * @internal
+ */
 final class AvailableAtStamp implements StampInterface
 {
     public function __construct(private \DateTimeImmutable $availableAt)

--- a/src/Transport/TestTransportFactory.php
+++ b/src/Transport/TestTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Zenstruck\Messenger\Test\Transport;
 
+use Psr\Clock\ClockInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -24,18 +25,13 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
  */
 final class TestTransportFactory implements TransportFactoryInterface
 {
-    private MessageBusInterface $bus;
-    private EventDispatcherInterface $dispatcher;
-
-    public function __construct(MessageBusInterface $bus, EventDispatcherInterface $dispatcher)
+    public function __construct(private MessageBusInterface $bus, private EventDispatcherInterface $dispatcher, private ClockInterface|null $clock = null)
     {
-        $this->bus = $bus;
-        $this->dispatcher = $dispatcher;
     }
 
     public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface // @phpstan-ignore-line
     {
-        return new TestTransport($options['transport_name'], $this->bus, $this->dispatcher, $serializer, $this->parseDsn($dsn));
+        return new TestTransport($options['transport_name'], $this->bus, $this->dispatcher, $serializer, $this->clock, $this->parseDsn($dsn));
     }
 
     public function supports(string $dsn, array $options): bool // @phpstan-ignore-line
@@ -59,6 +55,7 @@ final class TestTransportFactory implements TransportFactoryInterface
             'catch_exceptions' => \filter_var($query['catch_exceptions'] ?? true, \FILTER_VALIDATE_BOOLEAN),
             'test_serialization' => \filter_var($query['test_serialization'] ?? true, \FILTER_VALIDATE_BOOLEAN),
             'disable_retries' => \filter_var($query['disable_retries'] ?? true, \FILTER_VALIDATE_BOOLEAN),
+            'support_delay_stamp' => \filter_var($query['support_delay_stamp'] ?? true, \FILTER_VALIDATE_BOOLEAN),
         ];
     }
 }

--- a/src/ZenstruckMessengerTestBundle.php
+++ b/src/ZenstruckMessengerTestBundle.php
@@ -11,8 +11,10 @@
 
 namespace Zenstruck\Messenger\Test;
 
+use Psr\Clock\ClockInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -30,7 +32,11 @@ final class ZenstruckMessengerTestBundle extends Bundle implements CompilerPassI
     public function build(ContainerBuilder $container): void
     {
         $container->register('zenstruck_messenger_test.transport_factory', TestTransportFactory::class)
-            ->setArguments([new Reference('messenger.routable_message_bus'), new Reference('event_dispatcher')])
+            ->setArguments([
+                new Reference('messenger.routable_message_bus'),
+                new Reference('event_dispatcher'),
+                new Reference(ClockInterface::class, invalidBehavior: ContainerInterface::NULL_ON_INVALID_REFERENCE),
+            ])
             ->addTag('messenger.transport_factory')
         ;
 

--- a/tests/DelayStampTestTest.php
+++ b/tests/DelayStampTestTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-test package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Test\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Clock\Test\ClockSensitiveTrait;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Zenstruck\Messenger\Test\InteractsWithMessenger;
+use Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA;
+use Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageB;
+use Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageC;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ */
+final class DelayStampTestTest extends WebTestCase
+{
+    use InteractsWithMessenger;
+    use ClockSensitiveTrait;
+
+    /**
+     * @test
+     * @group legacy
+     */
+    public function it_handles_messages_sequentially_without_delay_stamp_support(): void
+    {
+        self::bootKernel(['environment' => 'delay_stamp_disabled']);
+
+        $transport = $this->transport('async');
+        $transport->send(new Envelope(new MessageA(), [new DelayStamp(10_000)]));
+        $transport->send(new Envelope(new MessageB()));
+        $transport->send(new Envelope(new MessageC(), [new DelayStamp(5_000)]));
+
+        $transport->acknowledged()->assertCount(0);
+
+        $transport->process(1)->acknowledged()->assertCount(1)->assertContains(MessageA::class);
+        $transport->process(1)->acknowledged()->assertCount(2)->assertContains(MessageB::class);
+        $transport->process(1)->acknowledged()->assertCount(3)->assertContains(MessageC::class);
+    }
+
+    /**
+     * @test
+     */
+    public function it_only_handles_message_without_delay_stamp_if_clock_not_mocked(): void
+    {
+        $transport = $this->transport('async');
+        $transport->send(new Envelope(new MessageA(), [new DelayStamp(10_000)]));
+        $transport->send(new Envelope(new MessageB()));
+        $transport->send(new Envelope(new MessageC(), [new DelayStamp(5_000)]));
+
+        $transport->acknowledged()->assertCount(0);
+
+        $transport->process(1)->acknowledged()->assertCount(1)->assertContains(MessageB::class);
+        $transport->process()->acknowledged()->assertCount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_messages_depending_on_delay_stamp(): void
+    {
+        $clock = self::mockTime();
+
+        $transport = $this->transport('async');
+        $transport->send(new Envelope(new MessageA(), [new DelayStamp(10_000)]));
+        $transport->send(new Envelope(new MessageB()));
+        $transport->send(new Envelope(new MessageC(), [new DelayStamp(5_000)]));
+
+        $transport->acknowledged()->assertCount(0);
+
+        $transport->process()->acknowledged()->assertCount(1)->assertContains(MessageB::class);
+
+        $clock->sleep(5);
+        $transport->process()->acknowledged()->assertCount(2)->assertContains(MessageC::class);
+
+        $clock->sleep(5);
+        $transport->process()->acknowledged()->assertCount(3)->assertContains(MessageA::class);
+    }
+
+    protected static function bootKernel(array $options = []): KernelInterface // @phpstan-ignore-line
+    {
+        return parent::bootKernel(\array_merge(['environment' => 'single_transport'], $options));
+    }
+}

--- a/tests/Fixture/Kernel.php
+++ b/tests/Fixture/Kernel.php
@@ -13,6 +13,7 @@ namespace Zenstruck\Messenger\Test\Tests\Fixture;
 
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Response;
@@ -45,6 +46,10 @@ class Kernel extends BaseKernel
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
     {
         $loader->load(\sprintf('%s/config/%s.yaml', __DIR__, $this->getEnvironment()));
+
+        if (class_exists(Clock::class) && !$c->has(\Psr\Clock\ClockInterface::class)) {
+            $c->register(\Psr\Clock\ClockInterface::class, Clock::class)->setPublic(true);
+        }
     }
 
     /**

--- a/tests/Fixture/config/default_sync_transport.yaml
+++ b/tests/Fixture/config/default_sync_transport.yaml
@@ -5,4 +5,4 @@ framework:
     messenger:
         transports:
             sync:
-                dsn: sync://
+                dsn: sync://?support_delay_stamp=true

--- a/tests/Fixture/config/delay_stamp_disabled.yaml
+++ b/tests/Fixture/config/delay_stamp_disabled.yaml
@@ -1,0 +1,12 @@
+imports:
+    - { resource: test.yaml }
+
+framework:
+    messenger:
+        transports:
+            async:
+                dsn: test://?disable_retries=false&support_delay_stamp=false
+        routing:
+            Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async]
+            Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageB: [async]
+            Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageC: [async]

--- a/tests/Fixture/config/multi_bus.yaml
+++ b/tests/Fixture/config/multi_bus.yaml
@@ -13,7 +13,7 @@ framework:
     messenger:
         transports:
             async:
-                dsn: test://?disable_retries=false
+                dsn: test://?disable_retries=false&support_delay_stamp=true
         routing:
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: async
         default_bus: bus_c

--- a/tests/Fixture/config/multi_transport.yaml
+++ b/tests/Fixture/config/multi_transport.yaml
@@ -5,12 +5,12 @@ framework:
     messenger:
         transports:
             async1:
-                dsn: test://
+                dsn: test://?support_delay_stamp=true
             async2:
-                dsn: test://?intercept=false&catch_exceptions=false&test_serialization=false
+                dsn: test://?intercept=false&catch_exceptions=false&test_serialization=false&support_delay_stamp=true
             async3: in-memory://
             async4:
-                dsn: test://?disable_retries=false
+                dsn: test://?disable_retries=false&support_delay_stamp=true
         routing:
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async1, async4]
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageB: [async2]

--- a/tests/Fixture/config/single_transport.yaml
+++ b/tests/Fixture/config/single_transport.yaml
@@ -5,7 +5,7 @@ framework:
     messenger:
         transports:
             async:
-                dsn: test://
+                dsn: test://?support_delay_stamp=true
         routing:
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async]
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageB: [async]

--- a/tests/InteractsWithBusTest.php
+++ b/tests/InteractsWithBusTest.php
@@ -62,15 +62,9 @@ class InteractsWithBusTest extends WebTestCase
         $this->bus('bus_b')->dispatched()->assertEmpty();
         $this->bus('bus_c')->dispatched()->assertEmpty();
 
-        self::getContainer()->get('bus_a')->dispatch(new MessageA(fail: true));
+        self::getContainer()->get('bus_a')->dispatch(new MessageA());
         self::getContainer()->get('bus_b')->dispatch(new MessageB());
         self::getContainer()->get('bus_c')->dispatch(new MessageC());
-
-        $this->transport()
-            ->process()
-            ->rejected()
-            ->assertContains(MessageA::class, 4)
-        ;
 
         $this->bus('bus_a')->dispatched()->assertCount(1);
         $this->bus('bus_b')->dispatched()->assertCount(1);


### PR DESCRIPTION
Hi!

here is a suggestion for supporting the `DelayStamp` in this lib.

Please, consider this PR as fully WIP, I'll add tests, and cleaner code once we're OK on some approach.

### Why is it needed?
we have some kind of home-made scheduler which permits to program some actions in the future, based on delay stamp, and we would like to be able to test this functionally by making "time jumps"

example:
```php
// somewhere in the app
$bus->dispatch(new Enevelope(new DoSomething1(), [new DelayStamp('+3 days')]));
$bus->dispatch(new Enevelope(new DoSomething2(), [new DelayStamp('+5 days')]));
```

```php
// somewhere in the tests

// 1. trigger the action that will dispatch the two previous messages by calling

// 2. assert no thing was done yet
$this->transport('scheduler')->process();
$this->transport('scheduler')->queue()->assertCount(2);

// 3. sleep and assert messages have been handled
$clock->sleep('3 days');
$this->transport('scheduler')->acknowledged()->assertContains(DoSomething1::class);
$this->asssertDoSomething1IsHandled();

$clock->sleep('2 days');
$this->transport('scheduler')->acknowledged()->assertContains(DoSomething2::class);
$this->asssertDoSomething2IsHandled();
```

### Some problem it may raise
- I think we'd need to make this feature opt-in per transport, otherwise, some user might have some surprises 😅
- I'm not sure what to do with retry behavior, because if someone tests the retries (so, they have `&disable_retries=false` inside the dsn of their transports), if they activate this feature along with retries, they'd need to make their app sleep in order to validate the retry. Or we may deactivate the feature for the retried messages, but this sounds cumbersome: delays will be handled, but not in all cases... 

WDYT?