### PR TITLE
Add attributes to support PHPUnit 10 + 11

### DIFF
--- a/src/InteractsWithMessenger.php
+++ b/src/InteractsWithMessenger.php
@@ -11,6 +11,8 @@
 
 namespace Zenstruck\Messenger\Test;
 
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Messenger\Test\Bus\TestBus;
 use Zenstruck\Messenger\Test\Bus\TestBusRegistry;
@@ -27,6 +29,7 @@ trait InteractsWithMessenger
      *
      * @before
      */
+    #[Before]
     final protected static function _initializeTestTransports(): void
     {
         TestTransport::initialize();
@@ -37,6 +40,7 @@ trait InteractsWithMessenger
      *
      * @before
      */
+    #[Before]
     final protected static function _enableMessagesCollection(): void
     {
         TestTransport::enableMessagesCollection();
@@ -48,6 +52,7 @@ trait InteractsWithMessenger
      *
      * @after
      */
+    #[After]
     final protected static function _disableMessagesCollection(): void
     {
         TestTransport::disableMessagesCollection();
@@ -59,6 +64,7 @@ trait InteractsWithMessenger
      *
      * @after
      */
+    #[After]
     final protected static function _resetMessengerTransports(): void
     {
         TestTransport::resetAll();


### PR DESCRIPTION
```
1) Metadata found in doc-comment for method
<redacted>::_initializeTestTransports(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.
2) Metadata found in doc-comment for method
<redacted>::_enableMessagesCollection(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.
3) Metadata found in doc-comment for method
<redacted>::_disableMessagesCollection(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.
4) Metadata found in doc-comment for method
<redacted>::_resetMessengerTransports(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.