### PR TITLE
Add installation step to add the bundle in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The transport also allows for processing these *queued* messages.
     ```bash
     composer require --dev zenstruck/messenger-test
     ```
-2. Add the bundle in `config/bundles.php`:
+2. If not added automatically by Symfony Flex, add the bundle in `config/bundles.php`:
 
     ```php
     Zenstruck\Messenger\Test\ZenstruckMessengerTestBundle::class => ['test' => true],

--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ The transport also allows for processing these *queued* messages.
     ```bash
     composer require --dev zenstruck/messenger-test
     ```
+2. Add the bundle in `config/bundles.php`:
 
-2. Update `config/packages/messenger.yaml` and override your transport(s)
+    ```php
+    Zenstruck\Messenger\Test\ZenstruckMessengerTestBundle::class => ['test' => true],
+    ```
+
+3. Update `config/packages/messenger.yaml` and override your transport(s)
 in your `test` environment with `test://`:
 
     ```yaml


### PR DESCRIPTION
I ran into an error and it was fixed by adding the bundle.

![image](https://github.com/zenstruck/messenger-test/assets/182954/036e90fb-a424-4b4a-b726-9bee1ca99b6d)

This might not happen to newer projects with recipes enabled.