### PR TITLE
feat: handler use deserialization version of the message with test_serialization=true #86

### DIFF
--- a/src/Transport/TestTransport.php
+++ b/src/Transport/TestTransport.php
@@ -248,6 +248,11 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
         }
 
         if (!$this->supportsDelayStamp()) {
+            if ($this->shouldTestSerialization()) {
+                // Simulate real transport by encoding/decoding the message
+                return [$this->serializer->decode($this->serializer->encode(\array_shift(self::$queue[$this->name])))];
+            }
+
             return [\array_shift(self::$queue[$this->name])];
         }
 
@@ -259,6 +264,11 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
             }
 
             unset(self::$queue[$this->name][$i]);
+
+            if ($this->shouldTestSerialization()) {
+                // Simulate real transport by encoding/decoding the message
+                return [$this->serializer->decode($this->serializer->encode($envelope))];
+            }
 
             return [$envelope];
         }

--- a/tests/Fixture/Messenger/MessageH.php
+++ b/tests/Fixture/Messenger/MessageH.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-test package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Zenstruck\Messenger\Test\Tests\Fixture\Messenger;
+
+class MessageH
+{
+    public function __construct(private readonly string $name)
+    {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function __serialize(): array
+    {
+        return [$this->name];
+    }
+
+
+    public function __unserialize(array $data): void
+    {
+        // make unserialization fail
+    }
+}

--- a/tests/Fixture/Messenger/MessageHHandler.php
+++ b/tests/Fixture/Messenger/MessageHHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-test package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Zenstruck\Messenger\Test\Tests\Fixture\Messenger;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class MessageHHandler
+{
+    public function __invoke(MessageH $message): void
+    {
+        // this will fail after serialization/deserialization
+        // @phpstan-ignore-next-line
+        $message->getName();
+    }
+}

--- a/tests/Fixture/config/multi_transport.yaml
+++ b/tests/Fixture/config/multi_transport.yaml
@@ -11,6 +11,8 @@ framework:
             async3: in-memory://
             async4:
                 dsn: test://?disable_retries=false&support_delay_stamp=true
+            async5:
+                dsn: test://?intercept=false&catch_exceptions=false&test_serialization=true&support_delay_stamp=true
         routing:
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async1, async4]
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageB: [async2]

--- a/tests/Fixture/config/test.yaml
+++ b/tests/Fixture/config/test.yaml
@@ -18,6 +18,8 @@ services:
         tags: [messenger.message_handler]
     Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageGHandler:
         tags: [messenger.message_handler]
+    Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageHHandler:
+        tags: [messenger.message_handler]
 
     message_bus:
         alias: Symfony\Component\Messenger\MessageBusInterface


### PR DESCRIPTION
Hello

This fix issue #86 it allow to completely test serialization/deserialization flow in messageHandler