### PR TITLE
Reset TestTransport on ensureKernelShutdown

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/deprecation-contracts": "^2.2|^3.0",
-        "symfony/framework-bundle": "^5.4|^6.0|^7.0",
+        "symfony/framework-bundle": "^5.4.44|^6.0|^7.0",
         "symfony/messenger": "^5.4|^6.0|^7.0",
         "zenstruck/assert": "^1.0"
     },

--- a/src/InteractsWithMessenger.php
+++ b/src/InteractsWithMessenger.php
@@ -50,6 +50,17 @@ trait InteractsWithMessenger
     /**
      * @internal
      *
+     * @before
+     */
+    #[Before]
+    final protected static function _disableResetOnKernelShutdown(): void
+    {
+        TestTransport::disableResetOnKernelShutdown();
+    }
+
+    /**
+     * @internal
+     *
      * @after
      */
     #[After]
@@ -69,6 +80,17 @@ trait InteractsWithMessenger
     {
         TestTransport::resetAll();
         TestBus::resetAll();
+    }
+
+    /**
+     * @internal
+     *
+     * @after
+     */
+    #[After]
+    final protected static function _enableResetOnKernelShutdown(): void
+    {
+        TestTransport::enableResetOnKernelShutdown();
     }
 
     /**

--- a/src/Transport/TestTransport.php
+++ b/src/Transport/TestTransport.php
@@ -77,6 +77,7 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
 
     // this setting applies to all transports
     private static bool $enableMessagesCollection = true;
+    private static bool $resetOnKernelShutdownEnabled = true;
 
     /**
      * @internal
@@ -409,6 +410,25 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
     public function supportsDelayStamp(): bool
     {
         return $this->clock && self::$supportDelayStamp[$this->name];
+    }
+
+    public function resetOnKernelShutdown(): void
+    {
+        if (!self::$resetOnKernelShutdownEnabled) {
+            return;
+        }
+
+        $this->reset();
+    }
+
+    public static function enableResetOnKernelShutdown(): void
+    {
+        self::$resetOnKernelShutdownEnabled = true;
+    }
+
+    public static function disableResetOnKernelShutdown(): void
+    {
+        self::$resetOnKernelShutdownEnabled = false;
     }
 
     /**

--- a/src/ZenstruckMessengerTestBundle.php
+++ b/src/ZenstruckMessengerTestBundle.php
@@ -62,14 +62,17 @@ final class ZenstruckMessengerTestBundle extends Bundle implements CompilerPassI
 
         foreach ($container->findTaggedServiceIds('messenger.receiver') as $id => $tags) {
             $name = $id;
+            $transport = $container->getDefinition($name);
 
-            if (!$class = $container->getDefinition($name)->getClass()) {
+            if (!$class = $transport->getClass()) {
                 continue;
             }
 
             if (!\is_a($class, TransportInterface::class, true)) {
                 continue;
             }
+
+            $transport->addTag('kernel.reset', ['method' => 'resetOnKernelShutdown', 'on_invalid' => 'ignore']);
 
             foreach ($tags as $tag) {
                 if (isset($tag['alias'])) {

--- a/tests/TransportsAreResetCorrectly/NotInteractsWithMessengerBeforeTest.php
+++ b/tests/TransportsAreResetCorrectly/NotInteractsWithMessengerBeforeTest.php
@@ -27,7 +27,7 @@ class NotInteractsWithMessengerBeforeTest extends KernelTestCase
 {
     public static function setUpBeforeClass(): void
     {
-        // Reset to default value to emulate first test in suit behavior
+        // Reset to default value to emulate first test in suite behavior
         TestTransport::enableMessagesCollection();
     }
 

--- a/tests/TransportsAreResetCorrectly/NotInteractsWithMessengerBeforeTest.php
+++ b/tests/TransportsAreResetCorrectly/NotInteractsWithMessengerBeforeTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA;
 use Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageAHandler;
+use Zenstruck\Messenger\Test\Transport\TestTransport;
 use Zenstruck\Messenger\Test\Transport\TestTransportRegistry;
 
 /**
@@ -24,6 +25,12 @@ use Zenstruck\Messenger\Test\Transport\TestTransportRegistry;
  */
 class NotInteractsWithMessengerBeforeTest extends KernelTestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        // Reset to default value to emulate first test in suit behavior
+        TestTransport::enableMessagesCollection();
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
An alternative approach to #82, requires https://github.com/symfony/symfony/pull/58240