### PR TITLE
feat: allow enabling / disabling retries manually

### DIFF
--- a/src/Transport/TestTransport.php
+++ b/src/Transport/TestTransport.php
@@ -147,6 +147,20 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
         return $this;
     }
 
+    public function enableRetries(): self
+    {
+        self::$disableRetries[$this->name] = false;
+
+        return $this;
+    }
+
+    public function disableRetries(): self
+    {
+        self::$disableRetries[$this->name] = true;
+
+        return $this;
+    }
+
     /**
      * Processes messages on the queue. This is done recursively so if handling
      * a message dispatches more messages, these will be processed as well (up

--- a/tests/InteractsWithMessengerTest.php
+++ b/tests/InteractsWithMessengerTest.php
@@ -492,6 +492,42 @@ final class InteractsWithMessengerTest extends WebTestCase
     /**
      * @test
      */
+    public function can_manually_enable_retries(): void
+    {
+        self::bootKernel();
+
+        $this->assertTrue($this->transport()->isRetriesDisabled());
+
+        $this->transport()->enableRetries();
+
+        $this->assertFalse($this->transport()->isRetriesDisabled());
+
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+
+        $this->transport()->process(1)->queue()->assertCount(1);
+    }
+
+    /**
+     * @test
+     */
+    public function can_manually_disable_retries(): void
+    {
+        self::bootKernel(['environment' => 'multi_transport']);
+
+        $this->assertFalse($this->transport('async4')->isRetriesDisabled());
+
+        $this->transport('async4')->disableRetries();
+
+        $this->assertTrue($this->transport('async4')->isRetriesDisabled());
+
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+
+        $this->transport('async4')->process()->queue()->assertEmpty();
+    }
+
+    /**
+     * @test
+     */
     public function can_disable_exception_catching_in_transport_config(): void
     {
         self::bootKernel(['environment' => 'multi_transport']);


### PR DESCRIPTION
This PR tries to allow manually (and conveniently) overriding the retry flag on a per-test basis.
I feel like most people tend to configure their TestTransports with disabled retries (globally).
However, when trying to test for instance a custom retry strategy, error listener, etc. I would like to enable retries just for this test case.

P.S. Thanks for this great Bundle. I just refactored a code base that had a custom variation of this with an InMemoryTransport. Was able to get rid of a lot of custom code and ended up with easier tests.
