### PR TITLE
feat: allow assert on failure transport

### DIFF
--- a/src/Transport/TestTransport.php
+++ b/src/Transport/TestTransport.php
@@ -16,10 +16,12 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTransportListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -175,6 +177,22 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
         // keep track of added listeners/subscribers so we can remove after
         $listeners = [];
         $subscribers = [];
+        // Keep track to SendFailedMessageToFailureTransportListener before replace it
+        $failureListener = null;
+        $failurePriority = 0;
+
+        foreach ($this->dispatcher->getListeners(WorkerMessageFailedEvent::class) as $listener) {
+            // skip Closure
+            if (!is_array($listener)) {
+                continue;
+            }
+            if (is_callable($listener) && $listener[0] instanceof SendFailedMessageToFailureTransportListener) {
+                $failureListener = $listener;
+                $failurePriority = $this->dispatcher->getListenerPriority(WorkerMessageFailedEvent::class, $failureListener) ?? 0;
+                $this->dispatcher->removeListener(WorkerMessageFailedEvent::class, $failureListener);
+                break;
+            }
+        }
 
         $this->dispatcher->addListener(
             WorkerRunningEvent::class,
@@ -198,9 +216,23 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
         if (!$this->isCatchingExceptions()) {
             $this->dispatcher->addListener(
                 WorkerMessageFailedEvent::class,
-                $listeners[WorkerMessageFailedEvent::class] = static function(WorkerMessageFailedEvent $event) {
+                $listeners[WorkerMessageFailedEvent::class][] = static function(WorkerMessageFailedEvent $event) {
                     throw $event->getThrowable();
                 },
+            );
+        }
+
+        if (null !== $failureListener) {
+            $isRetriesDisabled = $this->isRetriesDisabled();
+            $this->dispatcher->addListener(
+                WorkerMessageFailedEvent::class,
+                $listeners[WorkerMessageFailedEvent::class][] = static function(WorkerMessageFailedEvent $event) use ($isRetriesDisabled, $failureListener) {
+                    if ($isRetriesDisabled && $event->willRetry()) {
+                        $event = new WorkerMessageFailedEvent($event->getEnvelope(), $event->getReceiverName(), $event->getThrowable());
+                    }
+                    call_user_func($failureListener, $event);
+                },
+                $failurePriority
             );
         }
 
@@ -209,11 +241,21 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
 
         // remove added listeners/subscribers
         foreach ($listeners as $event => $listener) {
+            if (is_array($listener)) {
+                foreach ($listener as $subListener) {
+                    $this->dispatcher->removeListener($event, $subListener);
+                }
+                continue;
+            }
             $this->dispatcher->removeListener($event, $listener);
         }
 
         foreach ($subscribers as $subscriber) {
             $this->dispatcher->removeSubscriber($subscriber);
+        }
+
+        if (null !== $failureListener) {
+            $this->dispatcher->addListener(WorkerMessageFailedEvent::class, $failureListener, $failurePriority);
         }
 
         if ($number > 0) {
@@ -345,10 +387,14 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
             $envelope = $envelope->with(AvailableAtStamp::fromDelayStamp($delayStamp, $this->clock->now()));
         }
 
-        if ($this->isRetriesDisabled() && $envelope->last(RedeliveryStamp::class)) {
-            // message is being retried, don't process
+        $lastOriginalReceiver = $envelope->last(SentToFailureTransportStamp::class)?->getOriginalReceiverName();
+        if ($this->isRetriesDisabled() && $envelope->last(RedeliveryStamp::class) && (null === $lastOriginalReceiver || $this->name === $lastOriginalReceiver)) {
+            // message is being retried or emitted for failure by the same transport instance, don't process
             return $envelope;
         }
+
+        // remove for failure_transport processing capability without retry
+        $envelope = $envelope->withoutAll(SentToFailureTransportStamp::class);
 
         if ($this->shouldTestSerialization()) {
             Assert::try(

--- a/tests/Fixture/config/failure_transport.yaml
+++ b/tests/Fixture/config/failure_transport.yaml
@@ -1,0 +1,13 @@
+imports:
+    - { resource: test.yaml }
+
+framework:
+    messenger:
+        transports:
+            async:
+                dsn: test://?support_delay_stamp=true
+                failure_transport: failed
+            failed:
+                dsn: test://?support_delay_stamp=true
+        routing:
+            Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async]

--- a/tests/Fixture/config/global_failure_transport.yaml
+++ b/tests/Fixture/config/global_failure_transport.yaml
@@ -1,0 +1,13 @@
+imports:
+    - { resource: test.yaml }
+
+framework:
+    messenger:
+        failure_transport: failed
+        transports:
+            async:
+                dsn: test://?support_delay_stamp=true
+            failed:
+                dsn: test://?support_delay_stamp=true
+        routing:
+            Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async]

--- a/tests/InteractsWithMessengerTest.php
+++ b/tests/InteractsWithMessengerTest.php
@@ -1015,6 +1015,106 @@ final class InteractsWithMessengerTest extends WebTestCase
         $this->transport()->find(1);
     }
 
+    /**
+     * @test
+     */
+    public function message_send_to_failure_transport_on_fail(): void
+    {
+        self::bootKernel(['environment' => 'failure_transport']);
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+        $this->transport('async')->process(1)->rejected()->assertContains(MessageA::class, 1);
+        $this->transport('failed')->queue()->assertCount(1)->assertContains(MessageA::class, 1);
+    }
+
+
+    /**
+     * @test
+     */
+    public function message_send_to_failure_transport_on_fail_with_retry_enabled(): void
+    {
+        $clock = self::mockTime();
+        self::bootKernel(['environment' => 'failure_transport']);
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+        $async = $this->transport('async')->enableRetries();
+        $async->process()->rejected()->assertContains(MessageA::class, 1);
+        $clock->sleep(2);
+        $async->process()->rejected()->assertContains(MessageA::class, 2);
+        $clock->sleep(3);
+        $async->process()->rejected()->assertContains(MessageA::class, 3);
+        $clock->sleep(5);
+        $async->process()->rejected()->assertContains(MessageA::class, 4);
+        $this->transport('failed')->queue()->assertCount(1)->assertContains(MessageA::class, 1);
+    }
+
+    /**
+     * @test
+     */
+    public function message_send_to_global_failure_transport_on_fail(): void
+    {
+        self::bootKernel(['environment' => 'global_failure_transport']);
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+        $this->transport('async')->process()->rejected()->assertContains(MessageA::class, 1);
+        $this->transport('failed')->queue()->assertCount(1)->assertContains(MessageA::class, 1);
+    }
+
+
+    /**
+     * @test
+     */
+    public function message_send_to_global_failure_transport_on_fail_with_retry_enabled(): void
+    {
+        $clock = self::mockTime();
+        self::bootKernel(['environment' => 'global_failure_transport']);
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+        $async = $this->transport('async')->enableRetries();
+        $async->process()->rejected()->assertContains(MessageA::class, 1);
+        $clock->sleep(2);
+        $async->process()->rejected()->assertContains(MessageA::class, 2);
+        $clock->sleep(3);
+        $async->process()->rejected()->assertContains(MessageA::class, 3);
+        $clock->sleep(5);
+        $async->process()->rejected()->assertContains(MessageA::class, 4);
+        $this->transport('failed')->queue()->assertContains(MessageA::class, 1);
+    }
+
+    /**
+     * @test
+     */
+    public function message_send_to_global_failure_transport_process(): void
+    {
+        self::bootKernel(['environment' => 'global_failure_transport']);
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+        $this->transport('async')->process()->rejected()->assertContains(MessageA::class, 1);
+        $this->transport('failed')->process()->rejected()->assertContains(MessageA::class, 1);
+    }
+
+
+    /**
+     * @test
+     */
+    public function message_send_to_global_failure_transport_process_with_retry_enabled(): void
+    {
+        $clock = self::mockTime();
+        self::bootKernel(['environment' => 'global_failure_transport']);
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+        $async = $this->transport('async')->enableRetries();
+        $async->process()->rejected()->assertContains(MessageA::class, 1);
+        $clock->sleep(2);
+        $async->process()->rejected()->assertContains(MessageA::class, 2);
+        $clock->sleep(3);
+        $async->process()->rejected()->assertContains(MessageA::class, 3);
+        $clock->sleep(5);
+        $async->process()->rejected()->assertContains(MessageA::class, 4);
+        $failed = $this->transport('failed')->enableRetries();
+        $failed->process()->rejected()->assertContains(MessageA::class, 1);
+        $clock->sleep(2);
+        $failed->process()->rejected()->assertContains(MessageA::class, 2);
+        $clock->sleep(3);
+        $failed->process()->rejected()->assertContains(MessageA::class, 3);
+        $clock->sleep(5);
+        $failed->process()->rejected()->assertContains(MessageA::class/*, 4*/);
+    }
+
     protected static function bootKernel(array $options = []): KernelInterface // @phpstan-ignore-line
     {
         return parent::bootKernel(\array_merge(['environment' => 'single_transport'], $options));


### PR DESCRIPTION
I'm working on a solution to add assertions for the failure_transport.
I'm not sure this is the best approach, so please feel free to suggest changes, request additional tests, or reject the PR if needed.

Thanks for your work on messenger-test.

Related to : https://github.com/zenstruck/messenger-test/issues/71