### PR TITLE
fix: prevent TestTransport from increasing phpunit's assertions count

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,27 @@ when@test:
 > [!NOTE]
 > When using retries along with `support_delay_stamp` you must mock the time to sleep between retries.
 
+### Prevent Assertions Count
+
+By default, the `TestTransport` performs assertions internally, which impacts PHPUnit's assertions count.
+This hides risky tests from  the developer (a test doing no explicit assertion is not flagged as risky)
+and prevents using`expectNotToPerformAssertions()` in tests that only interact with the transport.
+
+This behavior is deprecated and can be disabled with the transport dsn:
+
+```yaml
+# config/packages/messenger.yaml
+
+when@test:
+    framework:
+        messenger:
+            transports:
+                async: test://?impacts_assertions_count=false
+```
+
+> [!NOTE]
+> Setting `impacts_assertions_count` to `false` will become the default behavior in 2.0.
+
 
 ## Bus
 

--- a/src/Transport/TestTransport.php
+++ b/src/Transport/TestTransport.php
@@ -41,6 +41,7 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
         'test_serialization' => true,
         'disable_retries' => true,
         'support_delay_stamp' => false,
+        'impacts_assertions_count' => true,
     ];
 
     private string $name;
@@ -63,6 +64,9 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
 
     /** @var array<string, bool> */
     private static array $supportDelayStamp = [];
+
+    /** @var array<string, bool> */
+    private static array $impactsAssertionsCount = [];
 
     /** @var array<string, Envelope[]> */
     private static array $dispatched = [];
@@ -100,6 +104,11 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
         self::$testSerialization[$name] ??= $options['test_serialization'];
         self::$disableRetries[$name] ??= $options['disable_retries'];
         self::$supportDelayStamp[$name] ??= $options['support_delay_stamp'];
+        self::$impactsAssertionsCount[$name] ??= $options['impacts_assertions_count'];
+
+        if (self::$impactsAssertionsCount[$name]) {
+            trigger_deprecation('zenstruck/messenger-test', '1.15.0', 'Allowing "TestTransport" to impact PHPUnit\'s assertions count is deprecated and will not be possible in 2.0');
+        }
 
         if (!self::$supportDelayStamp[$name]) {
             trigger_deprecation('zenstruck/messenger-test', '1.8.0', 'Not supporting DelayStamp is deprecated, support will be removed in 2.0.');
@@ -217,8 +226,12 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
             $this->dispatcher->removeSubscriber($subscriber);
         }
 
-        if ($number > 0 && $processCount !== $number) {
-            Assert::fail('Expected to process {expected} messages but only processed {actual}.', ['expected' => $number, 'actual' => $processCount]);
+        if ($number > 0) {
+            if ($this->impactsAssertionsCount()) {
+                Assert::that($processCount)->is($number, 'Expected to process {expected} messages but only processed {actual}.');
+            } elseif ($processCount !== $number) {
+                Assert::fail('Expected to process {expected} messages but only processed {actual}.', ['expected' => $number, 'actual' => $processCount]);
+            }
         }
 
         return $this;
@@ -229,7 +242,9 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
      */
     public function processOrFail(int $number = -1): self
     {
-        if (!$this->hasMessagesToProcess()) {
+        if ($this->impactsAssertionsCount()) {
+            Assert::true($this->hasMessagesToProcess(), 'No messages to process.');
+        } elseif (!$this->hasMessagesToProcess()) {
             Assert::fail('No messages to process.');
         }
 
@@ -358,10 +373,17 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
         }
 
         if ($this->shouldTestSerialization()) {
-            try {
-                $this->serializer->decode($this->serializer->encode($envelope));
-            } catch (Throwable $e) {
-                Assert::fail('A problem occurred in the serialization process.', ['exception' => $e, 'message' => $e->getMessage()]);
+            if ($this->impactsAssertionsCount()) {
+                Assert::try(
+                    fn() => $this->serializer->decode($this->serializer->encode($envelope)),
+                    'A problem occurred in the serialization process.',
+                );
+            } else {
+                try {
+                    $this->serializer->decode($this->serializer->encode($envelope));
+                } catch (Throwable $e) {
+                    Assert::fail('A problem occurred in the serialization process.', ['exception' => $e, 'message' => $e->getMessage()]);
+                }
             }
         }
 
@@ -394,7 +416,7 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
 
     public static function initialize(): void
     {
-        self::$intercept = self::$catchExceptions = self::$testSerialization = self::$disableRetries = self::$supportDelayStamp = [];
+        self::$intercept = self::$catchExceptions = self::$testSerialization = self::$disableRetries = self::$supportDelayStamp = self::$impactsAssertionsCount = [];
     }
 
     public static function enableMessagesCollection(): void
@@ -425,6 +447,11 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
     public function isRetriesDisabled(): bool
     {
         return self::$disableRetries[$this->name] ?? throw new \LogicException(\sprintf('Transport "%s" is not initialized.', $this->name));
+    }
+
+    public function impactsAssertionsCount(): bool
+    {
+        return self::$impactsAssertionsCount[$this->name] ?? throw new \LogicException(\sprintf('Transport "%s" is not initialized.', $this->name));
     }
 
     /**

--- a/src/Transport/TestTransport.php
+++ b/src/Transport/TestTransport.php
@@ -25,6 +25,7 @@ use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 use Symfony\Component\Messenger\Worker;
+use Throwable;
 use Zenstruck\Assert;
 use Zenstruck\Messenger\Test\Stamp\AvailableAtStamp;
 use Zenstruck\Messenger\Test\TestEnvelope;
@@ -216,8 +217,8 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
             $this->dispatcher->removeSubscriber($subscriber);
         }
 
-        if ($number > 0) {
-            Assert::that($processCount)->is($number, 'Expected to process {expected} messages but only processed {actual}.');
+        if ($number > 0 && $processCount !== $number) {
+            Assert::fail('Expected to process {expected} messages but only processed {actual}.', ['expected' => $number, 'actual' => $processCount]);
         }
 
         return $this;
@@ -228,7 +229,9 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
      */
     public function processOrFail(int $number = -1): self
     {
-        Assert::true($this->hasMessagesToProcess(), 'No messages to process.');
+        if (!$this->hasMessagesToProcess()) {
+            Assert::fail('No messages to process.');
+        }
 
         return $this->process($number);
     }
@@ -355,10 +358,11 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
         }
 
         if ($this->shouldTestSerialization()) {
-            Assert::try(
-                fn() => $this->serializer->decode($this->serializer->encode($envelope)),
-                'A problem occurred in the serialization process.',
-            );
+            try {
+                $this->serializer->decode($this->serializer->encode($envelope));
+            } catch (Throwable $e) {
+                Assert::fail('A problem occurred in the serialization process.', ['exception' => $e, 'message' => $e->getMessage()]);
+            }
         }
 
         $this->collectMessage(self::$dispatched, $envelope);

--- a/src/Transport/TestTransport.php
+++ b/src/Transport/TestTransport.php
@@ -107,7 +107,7 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
         self::$impactsAssertionsCount[$name] ??= $options['impacts_assertions_count'];
 
         if (self::$impactsAssertionsCount[$name]) {
-            trigger_deprecation('zenstruck/messenger-test', '1.15.0', 'Allowing "TestTransport" to impact PHPUnit\'s assertions count is deprecated and will not be possible in 2.0');
+            trigger_deprecation('zenstruck/messenger-test', '1.15.0', 'Allowing "TestTransport" to impact PHPUnit\'s assertions count is deprecated and will not be possible in 2.0. Set option "impacts_assertions_count" to "false" to prevent it.');
         }
 
         if (!self::$supportDelayStamp[$name]) {

--- a/src/Transport/TestTransportFactory.php
+++ b/src/Transport/TestTransportFactory.php
@@ -58,6 +58,7 @@ final class TestTransportFactory implements TransportFactoryInterface
             'test_serialization' => \filter_var($query['test_serialization'] ?? true, \FILTER_VALIDATE_BOOLEAN),
             'disable_retries' => \filter_var($query['disable_retries'] ?? true, \FILTER_VALIDATE_BOOLEAN),
             'support_delay_stamp' => \filter_var($query['support_delay_stamp'] ?? false, \FILTER_VALIDATE_BOOLEAN),
+            'impacts_assertions_count' => \filter_var($query['impacts_assertions_count'] ?? true, \FILTER_VALIDATE_BOOLEAN),
         ];
     }
 }

--- a/tests/Fixture/config/impacts_assertions_count_enabled.yaml
+++ b/tests/Fixture/config/impacts_assertions_count_enabled.yaml
@@ -5,10 +5,7 @@ framework:
     messenger:
         transports:
             async:
-                dsn: test://?disable_retries=false&support_delay_stamp=false&impacts_assertions_count=false
-                retry_strategy:
-                    service: messenger_test_retry_strategy
+                dsn: test://?support_delay_stamp=true&impacts_assertions_count=true
         routing:
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async]
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageB: [async]
-            Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageC: [async]

--- a/tests/Fixture/config/multi_bus.yaml
+++ b/tests/Fixture/config/multi_bus.yaml
@@ -13,7 +13,7 @@ framework:
     messenger:
         transports:
             async:
-                dsn: test://?disable_retries=false&support_delay_stamp=true
+                dsn: test://?disable_retries=false&support_delay_stamp=true&impacts_assertions_count=false
                 retry_strategy:
                     service: messenger_test_retry_strategy
         routing:

--- a/tests/Fixture/config/multi_transport.yaml
+++ b/tests/Fixture/config/multi_transport.yaml
@@ -5,16 +5,16 @@ framework:
     messenger:
         transports:
             async1:
-                dsn: test://?support_delay_stamp=true
+                dsn: test://?support_delay_stamp=true&impacts_assertions_count=false
             async2:
-                dsn: test://?intercept=false&catch_exceptions=false&test_serialization=false&support_delay_stamp=true
+                dsn: test://?intercept=false&catch_exceptions=false&test_serialization=false&support_delay_stamp=true&impacts_assertions_count=false
             async3: in-memory://
             async4:
-                dsn: test://?disable_retries=false&support_delay_stamp=true
+                dsn: test://?disable_retries=false&support_delay_stamp=true&impacts_assertions_count=false
                 retry_strategy:
                     service: messenger_test_retry_strategy
             async5:
-                dsn: test://?intercept=false&catch_exceptions=false&test_serialization=true&support_delay_stamp=true
+                dsn: test://?intercept=false&catch_exceptions=false&test_serialization=true&support_delay_stamp=true&impacts_assertions_count=false
         routing:
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async1, async4]
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageB: [async2]

--- a/tests/Fixture/config/single_transport.yaml
+++ b/tests/Fixture/config/single_transport.yaml
@@ -5,7 +5,7 @@ framework:
     messenger:
         transports:
             async:
-                dsn: test://?support_delay_stamp=true
+                dsn: test://?support_delay_stamp=true&impacts_assertions_count=false
         routing:
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async]
             Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageB: [async]

--- a/tests/InteractsWithMessengerTest.php
+++ b/tests/InteractsWithMessengerTest.php
@@ -917,9 +917,7 @@ final class InteractsWithMessengerTest extends WebTestCase
         $this->transport()->find(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function transport_operations_do_not_count_as_phpunit_assertions(): void
     {
         $this->expectNotToPerformAssertions();

--- a/tests/InteractsWithMessengerTest.php
+++ b/tests/InteractsWithMessengerTest.php
@@ -933,6 +933,19 @@ final class InteractsWithMessengerTest extends WebTestCase
         $this->transport()->processOrFail();
     }
 
+    #[Test]
+    #[IgnoreDeprecations]
+    public function transport_operations_still_work_when_counting_phpunit_assertions(): void
+    {
+        self::bootKernel(['environment' => 'impacts_assertions_count_enabled']);
+
+        $this->transport()->send(new Envelope(new MessageA()));
+        $this->transport()->process(1);
+
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA());
+        $this->transport()->processOrFail();
+    }
+
     protected static function bootKernel(array $options = []): KernelInterface // @phpstan-ignore-line
     {
         return parent::bootKernel(\array_merge(['environment' => 'single_transport'], $options));

--- a/tests/InteractsWithMessengerTest.php
+++ b/tests/InteractsWithMessengerTest.php
@@ -917,6 +917,22 @@ final class InteractsWithMessengerTest extends WebTestCase
         $this->transport()->find(1);
     }
 
+    /**
+     * @test
+     */
+    public function transport_operations_do_not_count_as_phpunit_assertions(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        self::bootKernel();
+
+        $this->transport()->send(new Envelope(new MessageA()));
+        $this->transport()->process(1);
+
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA());
+        $this->transport()->processOrFail();
+    }
+
     protected static function bootKernel(array $options = []): KernelInterface // @phpstan-ignore-line
     {
         return parent::bootKernel(\array_merge(['environment' => 'single_transport'], $options));

--- a/tests/Transport/TestTransportFactoryTest.php
+++ b/tests/Transport/TestTransportFactoryTest.php
@@ -16,6 +16,7 @@ namespace Zenstruck\Messenger\Test\Tests\Transport;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\Stub;
@@ -50,6 +51,7 @@ final class TestTransportFactoryTest extends TestCase
      * @param array<string, bool> $expectedOptions
      */
     #[Test]
+    #[IgnoreDeprecations]
     #[DataProvider('provideCreateTransportCases')]
     public function create_transport(string $dsn, array $options, array $expectedOptions): void
     {
@@ -69,6 +71,7 @@ final class TestTransportFactoryTest extends TestCase
             'test_serialization' => $transport->shouldTestSerialization(),
             'disable_retries' => $transport->isRetriesDisabled(),
             'support_delay_stamp' => $transport->supportsDelayStamp(),
+            'impacts_assertions_count' => $transport->impactsAssertionsCount(),
         ]);
     }
 
@@ -83,6 +86,7 @@ final class TestTransportFactoryTest extends TestCase
             'test_serialization' => true,
             'disable_retries' => true,
             'support_delay_stamp' => false,
+            'impacts_assertions_count' => true,
         ];
 
         yield 'pass options by dsn only' => ['test://?intercept=false&support_delay_stamp=true', [], [


### PR DESCRIPTION
 The transport is currently using asserts in its code that have two impacts :
- hides risky tests that do not perform assertions from the developer (since the transport is doing assertions, the test is not flagged as risky)  
- prevent developers who actually want to use `TestCase::expectNotToPerformAssertions` in their tests since the transport might do assertions

The change aims to only do asserts on failed actions (for instance, failed serialization) in order for risky tests to be visible