### PR TITLE
feat: allow assert on failure transport by fixing "disable retry" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,48 @@ when@test:
 > [!NOTE]
 > When using retries along with `support_delay_stamp` you must mock the time to sleep between retries.
 
+### Failure Transport
+
+When a transport is configured with a
+[failure transport](https://symfony.com/doc/current/messenger.html#saving-retrying-failed-messages),
+failed messages are forwarded to it exactly as they would be in production: immediately when
+retries are disabled (the default, see [Enable Retries](#enable-retries)) or once retries are
+exhausted. The failure transport is a `TestTransport` like any other, so you can assert on it:
+
+```yaml
+# config/packages/messenger.yaml
+
+when@test:
+    framework:
+        messenger:
+            failure_transport: failed
+            transports:
+                async: test://
+                failed: test://
+```
+
+```php
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Messenger\Test\InteractsWithMessenger;
+
+class MyTest extends KernelTestCase // or WebTestCase
+{
+    use InteractsWithMessenger;
+
+    public function test_failed_messages_are_sent_to_the_failure_transport(): void
+    {
+        // ...some code that routes a failing message to the "async" transport
+
+        $this->transport('async')->process(1)
+            ->rejected()->assertContains(MyMessage::class, 1)
+        ;
+
+        // the message has been forwarded to the "failed" failure transport
+        $this->transport('failed')->queue()->assertContains(MyMessage::class, 1);
+    }
+}
+```
+
 
 ## Bus
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=8.1",
         "symfony/deprecation-contracts": "^2.2|^3.0",
         "symfony/framework-bundle": "^6.4.15|^7.0|^8.0",
-        "symfony/messenger": "^6.4|^7.0|^8.0",
+        "symfony/messenger": "^6.4.4|^7.0|^8.0",
         "zenstruck/assert": "^1.0"
     },
     "require-dev": {

--- a/src/Retry/DisableableRetryStrategy.php
+++ b/src/Retry/DisableableRetryStrategy.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-test package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Test\Retry;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Retry\RetryStrategyInterface;
+use Zenstruck\Messenger\Test\Transport\TestTransport;
+
+/**
+ * @author Nicolas PHILIPPE <nikophil@gmail.com>
+ *
+ * @internal
+ */
+final class DisableableRetryStrategy implements RetryStrategyInterface
+{
+    public function __construct(
+        private RetryStrategyInterface $inner,
+        private string $transportName,
+    ) {
+    }
+
+    public function isRetryable(Envelope $message, ?\Throwable $throwable = null): bool
+    {
+        if (TestTransport::isRetriesDisabledFor($this->transportName)) {
+            return false;
+        }
+
+        return $this->inner->isRetryable($message, $throwable);
+    }
+
+    public function getWaitingTime(Envelope $message, ?\Throwable $throwable = null): int
+    {
+        return $this->inner->getWaitingTime($message, $throwable);
+    }
+}

--- a/src/Transport/TestTransport.php
+++ b/src/Transport/TestTransport.php
@@ -19,7 +19,6 @@ use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
-use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -204,16 +203,18 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
             );
         }
 
-        $worker = new Worker([$this->name => $this], $this->bus, $this->dispatcher);
-        $worker->run(['sleep' => 0]);
+        try {
+            $worker = new Worker([$this->name => $this], $this->bus, $this->dispatcher);
+            $worker->run(['sleep' => 0]);
+        } finally {
+            // remove added listeners/subscribers
+            foreach ($listeners as $event => $listener) {
+                $this->dispatcher->removeListener($event, $listener);
+            }
 
-        // remove added listeners/subscribers
-        foreach ($listeners as $event => $listener) {
-            $this->dispatcher->removeListener($event, $listener);
-        }
-
-        foreach ($subscribers as $subscriber) {
-            $this->dispatcher->removeSubscriber($subscriber);
+            foreach ($subscribers as $subscriber) {
+                $this->dispatcher->removeSubscriber($subscriber);
+            }
         }
 
         if ($number > 0) {
@@ -345,11 +346,6 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
             $envelope = $envelope->with(AvailableAtStamp::fromDelayStamp($delayStamp, $this->clock->now()));
         }
 
-        if ($this->isRetriesDisabled() && $envelope->last(RedeliveryStamp::class)) {
-            // message is being retried, don't process
-            return $envelope;
-        }
-
         if ($this->shouldTestSerialization()) {
             Assert::try(
                 fn() => $this->serializer->decode($this->serializer->encode($envelope)),
@@ -417,6 +413,14 @@ final class TestTransport implements TransportInterface, ListableReceiverInterfa
     public function isRetriesDisabled(): bool
     {
         return self::$disableRetries[$this->name] ?? throw new \LogicException(\sprintf('Transport "%s" is not initialized.', $this->name));
+    }
+
+    /**
+     * @internal
+     */
+    public static function isRetriesDisabledFor(string $name): bool
+    {
+        return self::$disableRetries[$name] ?? false;
     }
 
     /**

--- a/src/ZenstruckMessengerTestBundle.php
+++ b/src/ZenstruckMessengerTestBundle.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Messenger\Test;
 
 use Psr\Clock\ClockInterface;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 use Zenstruck\Messenger\Test\Bus\TestBus;
 use Zenstruck\Messenger\Test\Bus\TestBusRegistry;
+use Zenstruck\Messenger\Test\Retry\DisableableRetryStrategy;
 use Zenstruck\Messenger\Test\Transport\TestTransportFactory;
 use Zenstruck\Messenger\Test\Transport\TestTransportRegistry;
 
@@ -95,5 +97,41 @@ final class ZenstruckMessengerTestBundle extends Bundle implements CompilerPassI
                 ->setDecoratedService($id)
             ;
         }
+
+        $this->decorateRetryStrategies($container);
+    }
+
+    /**
+     * Wraps each transport's retry strategy with a {@see DisableableRetryStrategy} so retries can be
+     * toggled at runtime per transport (via TestTransport::enableRetries()/disableRetries()).
+     */
+    private function decorateRetryStrategies(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('messenger.retry_strategy_locator')) {
+            return;
+        }
+
+        $locator = $container->getDefinition('messenger.retry_strategy_locator');
+        $strategies = $locator->getArgument(0);
+
+        if (!\is_array($strategies)) {
+            return;
+        }
+
+        foreach ($strategies as $name => $strategy) {
+            // the locator arguments are plain References at this point (before ServiceLocatorTagPass),
+            // but handle the wrapped form too in case pass ordering ever changes
+            $inner = $strategy instanceof ServiceClosureArgument ? $strategy->getValues()[0] : $strategy;
+
+            $container->register($id = "zenstruck_messenger_test.retry_strategy.{$name}", DisableableRetryStrategy::class)
+                ->setArguments([$inner, $name])
+            ;
+
+            $strategies[$name] = $strategy instanceof ServiceClosureArgument
+                ? new ServiceClosureArgument(new Reference($id))
+                : new Reference($id);
+        }
+
+        $locator->replaceArgument(0, $strategies);
     }
 }

--- a/tests/Fixture/config/failure_transport.yaml
+++ b/tests/Fixture/config/failure_transport.yaml
@@ -1,0 +1,15 @@
+imports:
+    - { resource: test.yaml }
+
+framework:
+    messenger:
+        transports:
+            async:
+                dsn: test://?support_delay_stamp=true
+                failure_transport: failed
+                retry_strategy:
+                    service: messenger_test_retry_strategy
+            failed:
+                dsn: test://?support_delay_stamp=true
+        routing:
+            Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async]

--- a/tests/Fixture/config/global_failure_transport.yaml
+++ b/tests/Fixture/config/global_failure_transport.yaml
@@ -1,0 +1,13 @@
+imports:
+    - { resource: test.yaml }
+
+framework:
+    messenger:
+        failure_transport: failed
+        transports:
+            async:
+                dsn: test://?support_delay_stamp=true
+            failed:
+                dsn: test://?support_delay_stamp=true
+        routing:
+            Zenstruck\Messenger\Test\Tests\Fixture\Messenger\MessageA: [async]

--- a/tests/InteractsWithMessengerTest.php
+++ b/tests/InteractsWithMessengerTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Zenstruck\Assert;
@@ -915,6 +916,118 @@ final class InteractsWithMessengerTest extends WebTestCase
         $this->expectException(\BadMethodCallException::class);
 
         $this->transport()->find(1);
+    }
+
+    #[Test]
+    public function failed_messages_are_sent_to_the_failure_transport(): void
+    {
+        self::bootKernel(['environment' => 'failure_transport']);
+
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+
+        $this->transport('async')->process(1)->rejected()->assertContains(MessageA::class, 1);
+        $this->transport('failed')->queue()->assertCount(1)->assertContains(MessageA::class, 1);
+    }
+
+    #[Test]
+    public function messages_on_the_failure_transport_keep_the_sent_to_failure_stamp(): void
+    {
+        self::bootKernel(['environment' => 'failure_transport']);
+
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+
+        $this->transport('async')->process(1);
+
+        $stamp = $this->transport('failed')->queue()->first()->envelope->last(SentToFailureTransportStamp::class);
+
+        self::assertInstanceOf(SentToFailureTransportStamp::class, $stamp);
+        self::assertSame('async', $stamp->getOriginalReceiverName());
+    }
+
+    #[Test]
+    public function messages_are_retried_before_being_sent_to_the_failure_transport(): void
+    {
+        $clock = self::mockTime();
+
+        self::bootKernel(['environment' => 'failure_transport']);
+
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+
+        $async = $this->transport('async')->enableRetries();
+
+        // first attempt fails and is retried: nothing on the failure transport yet
+        $async->process()->rejected()->assertContains(MessageA::class, 1);
+        $this->transport('failed')->queue()->assertEmpty();
+
+        // the retry is now due and fails again: retries are exhausted, so the message is sent to the failure transport
+        $clock->sleep(1);
+        $async->process()->rejected()->assertContains(MessageA::class, 2);
+        $this->transport('failed')->queue()->assertCount(1)->assertContains(MessageA::class, 1);
+    }
+
+    #[Test]
+    public function failed_messages_are_sent_to_the_global_failure_transport(): void
+    {
+        self::bootKernel(['environment' => 'global_failure_transport']);
+
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+
+        $this->transport('async')->process(1)->rejected()->assertContains(MessageA::class, 1);
+        $this->transport('failed')->queue()->assertCount(1)->assertContains(MessageA::class, 1);
+    }
+
+    #[Test]
+    public function the_failure_transport_can_itself_be_processed(): void
+    {
+        self::bootKernel(['environment' => 'global_failure_transport']);
+
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+
+        $this->transport('async')->process(1);
+        $this->transport('failed')->queue()->assertCount(1);
+
+        // processing the failure transport must not loop the message back to itself
+        $this->transport('failed')->process(1)->rejected()->assertContains(MessageA::class, 1);
+        $this->transport('failed')->queue()->assertEmpty();
+    }
+
+    #[Test]
+    public function failed_messages_without_a_failure_transport_are_only_rejected(): void
+    {
+        self::bootKernel();
+
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new MessageA(true));
+
+        $this->transport()->process(1)->rejected()->assertContains(MessageA::class, 1);
+        $this->transport()->queue()->assertEmpty();
+    }
+
+    #[Test]
+    public function added_listeners_are_removed_after_a_throwing_process(): void
+    {
+        self::bootKernel(['environment' => 'failure_transport']);
+
+        $bus = self::getContainer()->get(MessageBusInterface::class);
+        $async = $this->transport('async');
+
+        // a throwing process() must still remove the listeners it registered (done in a finally block),
+        // otherwise the throw-on-failure listener would leak into the next process()
+        $async->throwExceptions();
+        $bus->dispatch(new MessageA(true));
+
+        try {
+            $async->process();
+
+            $this->fail('The exception should have been thrown.');
+        } catch (\RuntimeException $e) {
+            self::assertStringContainsString('handling failed...', $e->getMessage());
+        }
+
+        // the dispatcher is clean: enabling retries now re-queues the failed message instead of throwing
+        $async->catchExceptions()->enableRetries();
+        $bus->dispatch(new MessageA(true));
+
+        $async->process(1)->queue()->assertContains(MessageA::class, 1);
     }
 
     protected static function bootKernel(array $options = []): KernelInterface // @phpstan-ignore-line


### PR DESCRIPTION
supersedes https://github.com/zenstruck/messenger-test/pull/103

fixes https://github.com/zenstruck/messenger-test/issues/71
fixes #2

When retry is disabled (which is the default behavior in this lib), the listener `SendFailedMessageForRetryListener` still operates which prevents messages to be routed to failure transport